### PR TITLE
sds1104xe: support second ADC, generate TLAST for ADC AXIS

### DIFF
--- a/ip_repo/lxwrap_1.0/component.xml
+++ b/ip_repo/lxwrap_1.0/component.xml
@@ -216,7 +216,7 @@
       </spirit:parameters>
     </spirit:busInterface>
     <spirit:busInterface>
-      <spirit:name>adc0</spirit:name>
+      <spirit:name>adc0s</spirit:name>
       <spirit:description>ADC0 Output Stream</spirit:description>
       <spirit:busType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="axis" spirit:version="1.0"/>
       <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="axis_rtl" spirit:version="1.0"/>
@@ -246,6 +246,14 @@
             <spirit:name>adc0_tready</spirit:name>
           </spirit:physicalPort>
         </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>TLAST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>adc0_tlast</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
       </spirit:portMaps>
     </spirit:busInterface>
     <spirit:busInterface>
@@ -266,7 +274,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>ASSOCIATED_BUSIF</spirit:name>
-          <spirit:value spirit:id="BUSIFPARAM_VALUE.ADC_AXIS_CLK.ASSOCIATED_BUSIF">adc0</spirit:value>
+          <spirit:value spirit:id="BUSIFPARAM_VALUE.ADC_AXIS_CLK.ASSOCIATED_BUSIF">adc0s:adc1s</spirit:value>
         </spirit:parameter>
         <spirit:parameter>
           <spirit:name>ASSOCIATED_RESET</spirit:name>
@@ -286,6 +294,46 @@
           </spirit:logicalPort>
           <spirit:physicalPort>
             <spirit:name>adc_axis_rst</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>adc1s</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="axis" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="axis_rtl" spirit:version="1.0"/>
+      <spirit:master/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>TDATA</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>adc1_tdata</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>TLAST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>adc1_tlast</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>TVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>adc1_tvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>TREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>adc1_tready</spirit:name>
           </spirit:physicalPort>
         </spirit:portMap>
       </spirit:portMaps>
@@ -327,7 +375,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>7e56935c</spirit:value>
+            <spirit:value>f8a327b4</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -343,7 +391,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>7e56935c</spirit:value>
+            <spirit:value>f8a327b4</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -819,6 +867,95 @@
         </spirit:wire>
       </spirit:port>
       <spirit:port>
+        <spirit:name>adc0_tlast</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>adc1</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">19</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic_vector</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>adc1_tdata</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">63</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic_vector</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>adc1_tvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>adc1_tready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">1</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>adc1_tlast</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>std_logic</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
         <spirit:name>debug</spirit:name>
         <spirit:wire>
           <spirit:direction>out</spirit:direction>
@@ -876,7 +1013,7 @@
       <spirit:file>
         <spirit:name>hdl/lxwrap_v1_0.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_7e56935c</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_f8a327b4</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
@@ -943,8 +1080,8 @@
         <xilinx:taxonomy>AXI_Peripheral</xilinx:taxonomy>
       </xilinx:taxonomies>
       <xilinx:displayName>LiteX Logic Wrapper</xilinx:displayName>
-      <xilinx:coreRevision>17</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2018-08-04T13:12:24Z</xilinx:coreCreationDateTime>
+      <xilinx:coreRevision>19</xilinx:coreRevision>
+      <xilinx:coreCreationDateTime>2018-08-10T21:58:09Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="q3k.org:user:lxwrap:1.0_ARCHIVE_LOCATION">/project/fpga/ip_repo/lxwrap_1.0</xilinx:tag>
         <xilinx:tag xilinx:name="user.org:user:lxwrap:1.0_ARCHIVE_LOCATION">/project/fpga/ip_repo/lxwrap_1.0</xilinx:tag>
@@ -952,10 +1089,10 @@
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2018.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="87d4953e"/>
+      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="5c4fbb58"/>
       <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="ed1368d5"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="b628c147"/>
-      <xilinx:checksum xilinx:scope="ports" xilinx:value="69d42396"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="69991528"/>
+      <xilinx:checksum xilinx:scope="ports" xilinx:value="e4635c92"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="78a7093e"/>
     </xilinx:packagingInfo>
   </spirit:vendorExtensions>

--- a/ip_repo/lxwrap_1.0/hdl/lxwrap_v1_0.v
+++ b/ip_repo/lxwrap_1.0/hdl/lxwrap_v1_0.v
@@ -5,13 +5,19 @@ module top(
 	output reg spi_nSYNC,
 	output reg mux_nE,
 	output reg [2:0] mux_S,
-	input [19:0] adc0,
+	output reg [63:0] debug,
 	input adc_axis_clk,
 	input adc_axis_rst,
+	input [19:0] adc0,
 	output [63:0] adc0_tdata,
 	output adc0_tvalid,
 	input adc0_tready,
-	output reg [63:0] debug,
+	output adc0_tlast,
+	input [19:0] adc1,
+	output [63:0] adc1_tdata,
+	output adc1_tvalid,
+	input adc1_tready,
+	output adc1_tlast,
 	input [15:0] axi_lite_aw_addr,
 	input [2:0] axi_lite_aw_prot,
 	input axi_lite_aw_valid,
@@ -35,214 +41,311 @@ module top(
 	input sys_rst
 );
 
-reg [31:0] offsetdac_status = 32'd1047980;
-reg [31:0] offsetdac_control_storage_full = 32'd0;
-wire [31:0] offsetdac_control_storage;
-reg offsetdac_control_re = 1'd0;
-reg [31:0] offsetdac_clkdiv_storage_full = 32'd326;
-wire [31:0] offsetdac_clkdiv_storage;
-reg offsetdac_clkdiv_re = 1'd0;
-reg [31:0] offsetdac_enable_storage_full = 32'd1;
-wire [31:0] offsetdac_enable_storage;
-reg offsetdac_enable_re = 1'd0;
-reg [31:0] offsetdac_v0_storage_full = 32'd32768;
-wire [31:0] offsetdac_v0_storage;
-reg offsetdac_v0_re = 1'd0;
-reg [31:0] offsetdac_v1_storage_full = 32'd32768;
-wire [31:0] offsetdac_v1_storage;
-reg offsetdac_v1_re = 1'd0;
-reg [31:0] offsetdac_v2_storage_full = 32'd32768;
-wire [31:0] offsetdac_v2_storage;
-reg offsetdac_v2_re = 1'd0;
-reg [31:0] offsetdac_v3_storage_full = 32'd32768;
-wire [31:0] offsetdac_v3_storage;
-reg offsetdac_v3_re = 1'd0;
-reg [31:0] offsetdac_v4_storage_full = 32'd32768;
-wire [31:0] offsetdac_v4_storage;
-reg offsetdac_v4_re = 1'd0;
-reg [31:0] offsetdac_v5_storage_full = 32'd32768;
-wire [31:0] offsetdac_v5_storage;
-reg offsetdac_v5_re = 1'd0;
-reg [31:0] offsetdac_v6_storage_full = 32'd32768;
-wire [31:0] offsetdac_v6_storage;
-reg offsetdac_v6_re = 1'd0;
-reg [31:0] offsetdac_v7_storage_full = 32'd32768;
-wire [31:0] offsetdac_v7_storage;
-reg offsetdac_v7_re = 1'd0;
-reg [15:0] offsetdac_clkdiv = 16'd0;
-reg offsetdac_clk = 1'd0;
-reg offsetdac_clk_falling = 1'd0;
-reg [4:0] offsetdac_current_bit = 5'd0;
-reg [2:0] offsetdac_current_channel = 3'd0;
-reg [1:0] offsetdac_pd = 2'd0;
-reg [23:0] offsetdac_current_dac_word = 24'd0;
-reg [7:0] lvds_pads_adc0_d_p = 8'd0;
-reg [7:0] lvds_pads_adc0_d_n = 8'd0;
-wire lvds_pads_adc0_fclk_p;
-wire lvds_pads_adc0_fclk_n;
-wire lvds_pads_adc0_lclk_p;
-wire lvds_pads_adc0_lclk_n;
-reg [31:0] lvds_adc0_status = 32'd2780;
-reg [31:0] lvds_adc0_control_storage_full = 32'd0;
-wire [31:0] lvds_adc0_control_storage;
-reg lvds_adc0_control_re = 1'd0;
-reg lvds_adc0_rx_delay_rst = 1'd0;
-reg lvds_adc0_rx_delay_inc = 1'd0;
-reg lvds_adc0_bitslip_do = 1'd0;
-reg [63:0] lvds_adc0_d_preslip = 64'd0;
-wire [63:0] lvds_adc0_d;
-wire [7:0] lvds_adc0_fclk;
-wire lvds_adc0_d_clk;
-wire lvds_adc0_d_rst;
-wire lvds_adc0_d_valid;
-wire lvds_adc0_d_ready;
-wire [7:0] lvds_adc0_fclk_preslip;
-wire lvds_adc0_lclk_i;
-wire lvds_adc0_lclk_i_bufio;
-wire lclkdiv_clk;
-wire lclkdiv_rst;
-wire lvds_adc0_serdes_i_nodelay0;
-wire lvds_adc0_serdes_i_delayed0;
-wire [7:0] lvds_adc0_serdes_q0;
-wire lvds_adc0_serdes_i_nodelay1;
-wire lvds_adc0_serdes_i_delayed1;
-wire [7:0] lvds_adc0_serdes_q1;
-wire lvds_adc0_serdes_i_nodelay2;
-wire lvds_adc0_serdes_i_delayed2;
-wire [7:0] lvds_adc0_serdes_q2;
-wire lvds_adc0_serdes_i_nodelay3;
-wire lvds_adc0_serdes_i_delayed3;
-wire [7:0] lvds_adc0_serdes_q3;
-wire lvds_adc0_serdes_i_nodelay4;
-wire lvds_adc0_serdes_i_delayed4;
-wire [7:0] lvds_adc0_serdes_q4;
-wire lvds_adc0_serdes_i_nodelay5;
-wire lvds_adc0_serdes_i_delayed5;
-wire [7:0] lvds_adc0_serdes_q5;
-wire lvds_adc0_serdes_i_nodelay6;
-wire lvds_adc0_serdes_i_delayed6;
-wire [7:0] lvds_adc0_serdes_q6;
-wire lvds_adc0_serdes_i_nodelay7;
-wire lvds_adc0_serdes_i_delayed7;
-wire [7:0] lvds_adc0_serdes_q7;
-wire lvds_adc0_serdes_i_nodelay8;
-wire lvds_adc0_serdes_i_delayed8;
-wire [7:0] lvds_adc0_serdes_q8;
+reg [31:0] top_offsetdac_status = 32'd1047980;
+reg [31:0] top_offsetdac_control_storage_full = 32'd0;
+wire [31:0] top_offsetdac_control_storage;
+reg top_offsetdac_control_re = 1'd0;
+reg [31:0] top_offsetdac_clkdiv_storage_full = 32'd326;
+wire [31:0] top_offsetdac_clkdiv_storage;
+reg top_offsetdac_clkdiv_re = 1'd0;
+reg [31:0] top_offsetdac_enable_storage_full = 32'd1;
+wire [31:0] top_offsetdac_enable_storage;
+reg top_offsetdac_enable_re = 1'd0;
+reg [31:0] top_offsetdac_v0_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v0_storage;
+reg top_offsetdac_v0_re = 1'd0;
+reg [31:0] top_offsetdac_v1_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v1_storage;
+reg top_offsetdac_v1_re = 1'd0;
+reg [31:0] top_offsetdac_v2_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v2_storage;
+reg top_offsetdac_v2_re = 1'd0;
+reg [31:0] top_offsetdac_v3_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v3_storage;
+reg top_offsetdac_v3_re = 1'd0;
+reg [31:0] top_offsetdac_v4_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v4_storage;
+reg top_offsetdac_v4_re = 1'd0;
+reg [31:0] top_offsetdac_v5_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v5_storage;
+reg top_offsetdac_v5_re = 1'd0;
+reg [31:0] top_offsetdac_v6_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v6_storage;
+reg top_offsetdac_v6_re = 1'd0;
+reg [31:0] top_offsetdac_v7_storage_full = 32'd32768;
+wire [31:0] top_offsetdac_v7_storage;
+reg top_offsetdac_v7_re = 1'd0;
+reg [15:0] top_offsetdac_clkdiv = 16'd0;
+reg top_offsetdac_clk = 1'd0;
+reg top_offsetdac_clk_falling = 1'd0;
+reg [4:0] top_offsetdac_current_bit = 5'd0;
+reg [2:0] top_offsetdac_current_channel = 3'd0;
+reg [1:0] top_offsetdac_pd = 2'd0;
+reg [23:0] top_offsetdac_current_dac_word = 24'd0;
+reg [19:0] top_count = 20'd0;
+reg [7:0] top_record0_lvds_pads_adc_d_p = 8'd0;
+reg [7:0] top_record0_lvds_pads_adc_d_n = 8'd0;
+wire top_record0_lvds_pads_adc_fclk_p;
+wire top_record0_lvds_pads_adc_fclk_n;
+wire top_record0_lvds_pads_adc_lclk_p;
+wire top_record0_lvds_pads_adc_lclk_n;
+reg [31:0] top_lvdsreceiver0_status = 32'd2780;
+reg [31:0] top_lvdsreceiver0_control_storage_full = 32'd0;
+wire [31:0] top_lvdsreceiver0_control_storage;
+reg top_lvdsreceiver0_control_re = 1'd0;
+reg top_lvdsreceiver0_rx_delay_rst = 1'd0;
+reg top_lvdsreceiver0_rx_delay_inc = 1'd0;
+reg top_lvdsreceiver0_bitslip_do = 1'd0;
+reg [63:0] top_lvdsreceiver0_d_preslip = 64'd0;
+wire [63:0] top_lvdsreceiver0_d;
+wire [7:0] top_lvdsreceiver0_fclk;
+wire top_lvdsreceiver0_d_clk;
+wire top_lvdsreceiver0_d_rst;
+wire top_lvdsreceiver0_d_valid;
+wire top_lvdsreceiver0_d_last;
+wire top_lvdsreceiver0_d_ready;
+wire [7:0] top_lvdsreceiver0_fclk_preslip;
+wire top_lvdsreceiver0_lclk_i;
+wire top_lvdsreceiver0_lclk_i_bufio;
+wire adcif0_lclkdiv_clk;
+wire adcif0_lclkdiv_rst;
+wire top_lvdsreceiver0_serdes_i_nodelay0;
+wire top_lvdsreceiver0_serdes_i_delayed0;
+wire [7:0] top_lvdsreceiver0_serdes_q0;
+wire top_lvdsreceiver0_serdes_i_nodelay1;
+wire top_lvdsreceiver0_serdes_i_delayed1;
+wire [7:0] top_lvdsreceiver0_serdes_q1;
+wire top_lvdsreceiver0_serdes_i_nodelay2;
+wire top_lvdsreceiver0_serdes_i_delayed2;
+wire [7:0] top_lvdsreceiver0_serdes_q2;
+wire top_lvdsreceiver0_serdes_i_nodelay3;
+wire top_lvdsreceiver0_serdes_i_delayed3;
+wire [7:0] top_lvdsreceiver0_serdes_q3;
+wire top_lvdsreceiver0_serdes_i_nodelay4;
+wire top_lvdsreceiver0_serdes_i_delayed4;
+wire [7:0] top_lvdsreceiver0_serdes_q4;
+wire top_lvdsreceiver0_serdes_i_nodelay5;
+wire top_lvdsreceiver0_serdes_i_delayed5;
+wire [7:0] top_lvdsreceiver0_serdes_q5;
+wire top_lvdsreceiver0_serdes_i_nodelay6;
+wire top_lvdsreceiver0_serdes_i_delayed6;
+wire [7:0] top_lvdsreceiver0_serdes_q6;
+wire top_lvdsreceiver0_serdes_i_nodelay7;
+wire top_lvdsreceiver0_serdes_i_delayed7;
+wire [7:0] top_lvdsreceiver0_serdes_q7;
+wire top_lvdsreceiver0_serdes_i_nodelay8;
+wire top_lvdsreceiver0_serdes_i_delayed8;
+wire [7:0] top_lvdsreceiver0_serdes_q8;
+wire adcif0_data_clk;
+wire adcif0_data_rst;
+wire top_lvdsreceiver0_data_fifo_re;
+reg top_lvdsreceiver0_data_fifo_readable = 1'd0;
+reg [71:0] top_lvdsreceiver0_data_fifo_dout = 72'd0;
+wire top_lvdsreceiver0_data_fifo_asyncfifo0_we;
+wire top_lvdsreceiver0_data_fifo_asyncfifo0_writable;
+wire top_lvdsreceiver0_data_fifo_asyncfifo0_re;
+wire top_lvdsreceiver0_data_fifo_asyncfifo0_readable;
+reg [71:0] top_lvdsreceiver0_data_fifo_asyncfifo0_din = 72'd0;
+wire [71:0] top_lvdsreceiver0_data_fifo_asyncfifo0_dout;
+wire top_lvdsreceiver0_data_fifo_graycounter0_ce;
+(* no_retiming = "true" *) reg [6:0] top_lvdsreceiver0_data_fifo_graycounter0_q = 7'd0;
+wire [6:0] top_lvdsreceiver0_data_fifo_graycounter0_q_next;
+reg [6:0] top_lvdsreceiver0_data_fifo_graycounter0_q_binary = 7'd0;
+reg [6:0] top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary = 7'd0;
+wire top_lvdsreceiver0_data_fifo_graycounter1_ce;
+(* no_retiming = "true" *) reg [6:0] top_lvdsreceiver0_data_fifo_graycounter1_q = 7'd0;
+wire [6:0] top_lvdsreceiver0_data_fifo_graycounter1_q_next;
+reg [6:0] top_lvdsreceiver0_data_fifo_graycounter1_q_binary = 7'd0;
+reg [6:0] top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary = 7'd0;
+wire [6:0] top_lvdsreceiver0_data_fifo_produce_rdomain;
+wire [6:0] top_lvdsreceiver0_data_fifo_consume_wdomain;
+wire [5:0] top_lvdsreceiver0_data_fifo_wrport_adr;
+wire [71:0] top_lvdsreceiver0_data_fifo_wrport_dat_r;
+wire top_lvdsreceiver0_data_fifo_wrport_we;
+wire [71:0] top_lvdsreceiver0_data_fifo_wrport_dat_w;
+wire [5:0] top_lvdsreceiver0_data_fifo_rdport_adr;
+wire [71:0] top_lvdsreceiver0_data_fifo_rdport_dat_r;
+reg [15:0] top_lvdsreceiver0_bitslip_delay = 16'd0;
+reg [13:0] top_lvdsreceiver0_last_counter = 14'd0;
+reg [7:0] top_record1_lvds_pads_adc_d_p = 8'd0;
+reg [7:0] top_record1_lvds_pads_adc_d_n = 8'd0;
+wire top_record1_lvds_pads_adc_fclk_p;
+wire top_record1_lvds_pads_adc_fclk_n;
+wire top_record1_lvds_pads_adc_lclk_p;
+wire top_record1_lvds_pads_adc_lclk_n;
+reg [31:0] top_lvdsreceiver1_status = 32'd2780;
+reg [31:0] top_lvdsreceiver1_control_storage_full = 32'd0;
+wire [31:0] top_lvdsreceiver1_control_storage;
+reg top_lvdsreceiver1_control_re = 1'd0;
+reg top_lvdsreceiver1_rx_delay_rst = 1'd0;
+reg top_lvdsreceiver1_rx_delay_inc = 1'd0;
+reg top_lvdsreceiver1_bitslip_do = 1'd0;
+reg [63:0] top_lvdsreceiver1_d_preslip = 64'd0;
+wire [63:0] top_lvdsreceiver1_d;
+wire [7:0] top_lvdsreceiver1_fclk;
+wire top_lvdsreceiver1_d_clk;
+wire top_lvdsreceiver1_d_rst;
+wire top_lvdsreceiver1_d_valid;
+wire top_lvdsreceiver1_d_last;
+wire top_lvdsreceiver1_d_ready;
+wire [7:0] top_lvdsreceiver1_fclk_preslip;
+wire top_lvdsreceiver1_lclk_i;
+wire top_lvdsreceiver1_lclk_i_bufio;
+wire adcif1_lclkdiv_clk;
+wire adcif1_lclkdiv_rst;
+wire top_lvdsreceiver1_serdes_i_nodelay0;
+wire top_lvdsreceiver1_serdes_i_delayed0;
+wire [7:0] top_lvdsreceiver1_serdes_q0;
+wire top_lvdsreceiver1_serdes_i_nodelay1;
+wire top_lvdsreceiver1_serdes_i_delayed1;
+wire [7:0] top_lvdsreceiver1_serdes_q1;
+wire top_lvdsreceiver1_serdes_i_nodelay2;
+wire top_lvdsreceiver1_serdes_i_delayed2;
+wire [7:0] top_lvdsreceiver1_serdes_q2;
+wire top_lvdsreceiver1_serdes_i_nodelay3;
+wire top_lvdsreceiver1_serdes_i_delayed3;
+wire [7:0] top_lvdsreceiver1_serdes_q3;
+wire top_lvdsreceiver1_serdes_i_nodelay4;
+wire top_lvdsreceiver1_serdes_i_delayed4;
+wire [7:0] top_lvdsreceiver1_serdes_q4;
+wire top_lvdsreceiver1_serdes_i_nodelay5;
+wire top_lvdsreceiver1_serdes_i_delayed5;
+wire [7:0] top_lvdsreceiver1_serdes_q5;
+wire top_lvdsreceiver1_serdes_i_nodelay6;
+wire top_lvdsreceiver1_serdes_i_delayed6;
+wire [7:0] top_lvdsreceiver1_serdes_q6;
+wire top_lvdsreceiver1_serdes_i_nodelay7;
+wire top_lvdsreceiver1_serdes_i_delayed7;
+wire [7:0] top_lvdsreceiver1_serdes_q7;
+wire top_lvdsreceiver1_serdes_i_nodelay8;
+wire top_lvdsreceiver1_serdes_i_delayed8;
+wire [7:0] top_lvdsreceiver1_serdes_q8;
+wire adcif1_data_clk;
+wire adcif1_data_rst;
+wire top_lvdsreceiver1_data_fifo_re;
+reg top_lvdsreceiver1_data_fifo_readable = 1'd0;
+reg [71:0] top_lvdsreceiver1_data_fifo_dout = 72'd0;
+wire top_lvdsreceiver1_data_fifo_asyncfifo1_we;
+wire top_lvdsreceiver1_data_fifo_asyncfifo1_writable;
+wire top_lvdsreceiver1_data_fifo_asyncfifo1_re;
+wire top_lvdsreceiver1_data_fifo_asyncfifo1_readable;
+reg [71:0] top_lvdsreceiver1_data_fifo_asyncfifo1_din = 72'd0;
+wire [71:0] top_lvdsreceiver1_data_fifo_asyncfifo1_dout;
+wire top_lvdsreceiver1_data_fifo_graycounter2_ce;
+(* no_retiming = "true" *) reg [6:0] top_lvdsreceiver1_data_fifo_graycounter2_q = 7'd0;
+wire [6:0] top_lvdsreceiver1_data_fifo_graycounter2_q_next;
+reg [6:0] top_lvdsreceiver1_data_fifo_graycounter2_q_binary = 7'd0;
+reg [6:0] top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary = 7'd0;
+wire top_lvdsreceiver1_data_fifo_graycounter3_ce;
+(* no_retiming = "true" *) reg [6:0] top_lvdsreceiver1_data_fifo_graycounter3_q = 7'd0;
+wire [6:0] top_lvdsreceiver1_data_fifo_graycounter3_q_next;
+reg [6:0] top_lvdsreceiver1_data_fifo_graycounter3_q_binary = 7'd0;
+reg [6:0] top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary = 7'd0;
+wire [6:0] top_lvdsreceiver1_data_fifo_produce_rdomain;
+wire [6:0] top_lvdsreceiver1_data_fifo_consume_wdomain;
+wire [5:0] top_lvdsreceiver1_data_fifo_wrport_adr;
+wire [71:0] top_lvdsreceiver1_data_fifo_wrport_dat_r;
+wire top_lvdsreceiver1_data_fifo_wrport_we;
+wire [71:0] top_lvdsreceiver1_data_fifo_wrport_dat_w;
+wire [5:0] top_lvdsreceiver1_data_fifo_rdport_adr;
+wire [71:0] top_lvdsreceiver1_data_fifo_rdport_dat_r;
+reg [15:0] top_lvdsreceiver1_bitslip_delay = 16'd0;
+reg [13:0] top_lvdsreceiver1_last_counter = 14'd0;
 wire data_clk;
 wire data_rst;
-wire lvds_adc0_data_fifo_re;
-reg lvds_adc0_data_fifo_readable = 1'd0;
-reg [71:0] lvds_adc0_data_fifo_dout = 72'd0;
-wire lvds_adc0_data_fifo_asyncfifo_we;
-wire lvds_adc0_data_fifo_asyncfifo_writable;
-wire lvds_adc0_data_fifo_asyncfifo_re;
-wire lvds_adc0_data_fifo_asyncfifo_readable;
-reg [71:0] lvds_adc0_data_fifo_asyncfifo_din = 72'd0;
-wire [71:0] lvds_adc0_data_fifo_asyncfifo_dout;
-wire lvds_adc0_data_fifo_graycounter0_ce;
-(* no_retiming = "true" *) reg [6:0] lvds_adc0_data_fifo_graycounter0_q = 7'd0;
-wire [6:0] lvds_adc0_data_fifo_graycounter0_q_next;
-reg [6:0] lvds_adc0_data_fifo_graycounter0_q_binary = 7'd0;
-reg [6:0] lvds_adc0_data_fifo_graycounter0_q_next_binary = 7'd0;
-wire lvds_adc0_data_fifo_graycounter1_ce;
-(* no_retiming = "true" *) reg [6:0] lvds_adc0_data_fifo_graycounter1_q = 7'd0;
-wire [6:0] lvds_adc0_data_fifo_graycounter1_q_next;
-reg [6:0] lvds_adc0_data_fifo_graycounter1_q_binary = 7'd0;
-reg [6:0] lvds_adc0_data_fifo_graycounter1_q_next_binary = 7'd0;
-wire [6:0] lvds_adc0_data_fifo_produce_rdomain;
-wire [6:0] lvds_adc0_data_fifo_consume_wdomain;
-wire [5:0] lvds_adc0_data_fifo_wrport_adr;
-wire [71:0] lvds_adc0_data_fifo_wrport_dat_r;
-wire lvds_adc0_data_fifo_wrport_we;
-wire [71:0] lvds_adc0_data_fifo_wrport_dat_w;
-wire [5:0] lvds_adc0_data_fifo_rdport_adr;
-wire [71:0] lvds_adc0_data_fifo_rdport_dat_r;
-reg [15:0] lvds_adc0_bitslip_delay = 16'd0;
-reg [19:0] count = 20'd0;
-wire data_clk_1;
-wire data_rst_1;
-wire [13:0] csr_adr;
-wire csr_we;
-wire [31:0] csr_dat_w;
-wire [31:0] csr_dat_r;
-wire busy;
-wire write_transaction;
-wire read_transaction;
-reg [31:0] wdata = 32'd0;
-reg [15:0] addr = 16'd0;
-reg is_ongoing0 = 1'd0;
-reg is_ongoing1 = 1'd0;
-reg is_ongoing2 = 1'd0;
-wire [13:0] interface0_bank_bus_adr;
-wire interface0_bank_bus_we;
-wire [31:0] interface0_bank_bus_dat_w;
-reg [31:0] interface0_bank_bus_dat_r = 32'd0;
-wire csrbank0_status_re;
-wire [31:0] csrbank0_status_r;
-wire [31:0] csrbank0_status_w;
-wire csrbank0_control0_re;
-wire [31:0] csrbank0_control0_r;
-wire [31:0] csrbank0_control0_w;
-wire csrbank0_sel;
-wire [13:0] interface1_bank_bus_adr;
-wire interface1_bank_bus_we;
-wire [31:0] interface1_bank_bus_dat_w;
-reg [31:0] interface1_bank_bus_dat_r = 32'd0;
-wire csrbank1_status_re;
-wire [31:0] csrbank1_status_r;
-wire [31:0] csrbank1_status_w;
-wire csrbank1_control0_re;
-wire [31:0] csrbank1_control0_r;
-wire [31:0] csrbank1_control0_w;
-wire csrbank1_clkdiv0_re;
-wire [31:0] csrbank1_clkdiv0_r;
-wire [31:0] csrbank1_clkdiv0_w;
-wire csrbank1_enable0_re;
-wire [31:0] csrbank1_enable0_r;
-wire [31:0] csrbank1_enable0_w;
-wire csrbank1_v00_re;
-wire [31:0] csrbank1_v00_r;
-wire [31:0] csrbank1_v00_w;
-wire csrbank1_v10_re;
-wire [31:0] csrbank1_v10_r;
-wire [31:0] csrbank1_v10_w;
-wire csrbank1_v20_re;
-wire [31:0] csrbank1_v20_r;
-wire [31:0] csrbank1_v20_w;
-wire csrbank1_v30_re;
-wire [31:0] csrbank1_v30_r;
-wire [31:0] csrbank1_v30_w;
-wire csrbank1_v40_re;
-wire [31:0] csrbank1_v40_r;
-wire [31:0] csrbank1_v40_w;
-wire csrbank1_v50_re;
-wire [31:0] csrbank1_v50_r;
-wire [31:0] csrbank1_v50_w;
-wire csrbank1_v60_re;
-wire [31:0] csrbank1_v60_r;
-wire [31:0] csrbank1_v60_w;
-wire csrbank1_v70_re;
-wire [31:0] csrbank1_v70_r;
-wire [31:0] csrbank1_v70_w;
-wire csrbank1_sel;
+wire [13:0] top_csr_adr;
+wire top_csr_we;
+wire [31:0] top_csr_dat_w;
+wire [31:0] top_csr_dat_r;
+wire top_busy;
+wire top_write_transaction;
+wire top_read_transaction;
+reg [31:0] top_wdata = 32'd0;
+reg [15:0] top_addr = 16'd0;
+reg top_is_ongoing0 = 1'd0;
+reg top_is_ongoing1 = 1'd0;
+reg top_is_ongoing2 = 1'd0;
+wire [13:0] top_interface0_bank_bus_adr;
+wire top_interface0_bank_bus_we;
+wire [31:0] top_interface0_bank_bus_dat_w;
+reg [31:0] top_interface0_bank_bus_dat_r = 32'd0;
+wire top_csrbank0_status_re;
+wire [31:0] top_csrbank0_status_r;
+wire [31:0] top_csrbank0_status_w;
+wire top_csrbank0_control0_re;
+wire [31:0] top_csrbank0_control0_r;
+wire [31:0] top_csrbank0_control0_w;
+wire top_csrbank0_sel;
+wire [13:0] top_interface1_bank_bus_adr;
+wire top_interface1_bank_bus_we;
+wire [31:0] top_interface1_bank_bus_dat_w;
+reg [31:0] top_interface1_bank_bus_dat_r = 32'd0;
+wire top_csrbank1_status_re;
+wire [31:0] top_csrbank1_status_r;
+wire [31:0] top_csrbank1_status_w;
+wire top_csrbank1_control0_re;
+wire [31:0] top_csrbank1_control0_r;
+wire [31:0] top_csrbank1_control0_w;
+wire top_csrbank1_sel;
+wire [13:0] top_interface2_bank_bus_adr;
+wire top_interface2_bank_bus_we;
+wire [31:0] top_interface2_bank_bus_dat_w;
+reg [31:0] top_interface2_bank_bus_dat_r = 32'd0;
+wire top_csrbank2_status_re;
+wire [31:0] top_csrbank2_status_r;
+wire [31:0] top_csrbank2_status_w;
+wire top_csrbank2_control0_re;
+wire [31:0] top_csrbank2_control0_r;
+wire [31:0] top_csrbank2_control0_w;
+wire top_csrbank2_clkdiv0_re;
+wire [31:0] top_csrbank2_clkdiv0_r;
+wire [31:0] top_csrbank2_clkdiv0_w;
+wire top_csrbank2_enable0_re;
+wire [31:0] top_csrbank2_enable0_r;
+wire [31:0] top_csrbank2_enable0_w;
+wire top_csrbank2_v00_re;
+wire [31:0] top_csrbank2_v00_r;
+wire [31:0] top_csrbank2_v00_w;
+wire top_csrbank2_v10_re;
+wire [31:0] top_csrbank2_v10_r;
+wire [31:0] top_csrbank2_v10_w;
+wire top_csrbank2_v20_re;
+wire [31:0] top_csrbank2_v20_r;
+wire [31:0] top_csrbank2_v20_w;
+wire top_csrbank2_v30_re;
+wire [31:0] top_csrbank2_v30_r;
+wire [31:0] top_csrbank2_v30_w;
+wire top_csrbank2_v40_re;
+wire [31:0] top_csrbank2_v40_r;
+wire [31:0] top_csrbank2_v40_w;
+wire top_csrbank2_v50_re;
+wire [31:0] top_csrbank2_v50_r;
+wire [31:0] top_csrbank2_v50_w;
+wire top_csrbank2_v60_re;
+wire [31:0] top_csrbank2_v60_r;
+wire [31:0] top_csrbank2_v60_w;
+wire top_csrbank2_v70_re;
+wire [31:0] top_csrbank2_v70_r;
+wire [31:0] top_csrbank2_v70_w;
+wire top_csrbank2_sel;
 reg offsetdac_state = 1'd0;
 reg offsetdac_next_state = 1'd0;
-reg [4:0] offsetdac_current_bit_offsetdac_next_value0 = 5'd0;
-reg offsetdac_current_bit_offsetdac_next_value_ce0 = 1'd0;
-reg offsetdac_mux_nE_offsetdac_next_value1 = 1'd0;
-reg offsetdac_mux_nE_offsetdac_next_value_ce1 = 1'd0;
-reg offsetdac_spi_nSYNC_offsetdac_next_value2 = 1'd0;
-reg offsetdac_spi_nSYNC_offsetdac_next_value_ce2 = 1'd0;
-reg offsetdac_spi_DIN_offsetdac_next_value3 = 1'd0;
-reg offsetdac_spi_DIN_offsetdac_next_value_ce3 = 1'd0;
-reg [2:0] offsetdac_current_channel_offsetdac_f_next_value = 3'd0;
-reg offsetdac_current_channel_offsetdac_f_next_value_ce = 1'd0;
-reg [2:0] offsetdac_mux_S_offsetdac_t_next_value = 3'd0;
-reg offsetdac_mux_S_offsetdac_t_next_value_ce = 1'd0;
+reg [4:0] top_offsetdac_current_bit_offsetdac_next_value0 = 5'd0;
+reg top_offsetdac_current_bit_offsetdac_next_value_ce0 = 1'd0;
+reg top_offsetdac_mux_nE_offsetdac_next_value1 = 1'd0;
+reg top_offsetdac_mux_nE_offsetdac_next_value_ce1 = 1'd0;
+reg top_offsetdac_spi_nSYNC_offsetdac_next_value2 = 1'd0;
+reg top_offsetdac_spi_nSYNC_offsetdac_next_value_ce2 = 1'd0;
+reg top_offsetdac_spi_DIN_offsetdac_next_value3 = 1'd0;
+reg top_offsetdac_spi_DIN_offsetdac_next_value_ce3 = 1'd0;
+reg [2:0] top_offsetdac_current_channel_offsetdac_f_next_value = 3'd0;
+reg top_offsetdac_current_channel_offsetdac_f_next_value_ce = 1'd0;
+reg [2:0] top_offsetdac_mux_S_offsetdac_t_next_value = 3'd0;
+reg top_offsetdac_mux_S_offsetdac_t_next_value_ce = 1'd0;
 reg [1:0] axilite2csr_state = 2'd0;
 reg [1:0] axilite2csr_next_state = 2'd0;
-reg [31:0] wdata_axilite2csr_next_value = 32'd0;
-reg wdata_axilite2csr_next_value_ce = 1'd0;
+reg [31:0] top_wdata_axilite2csr_next_value = 32'd0;
+reg top_wdata_axilite2csr_next_value_ce = 1'd0;
 reg [15:0] rhs_array_muxed = 16'd0;
 reg cases_array_muxed = 1'd0;
 (* no_retiming = "true" *) reg multiregimpl0_regs0 = 1'd0;
@@ -251,650 +354,831 @@ reg cases_array_muxed = 1'd0;
 (* no_retiming = "true" *) reg [6:0] multiregimpl1_regs1 = 7'd0;
 (* no_retiming = "true" *) reg [6:0] multiregimpl2_regs0 = 7'd0;
 (* no_retiming = "true" *) reg [6:0] multiregimpl2_regs1 = 7'd0;
+(* no_retiming = "true" *) reg multiregimpl3_regs0 = 1'd0;
+(* no_retiming = "true" *) reg multiregimpl3_regs1 = 1'd0;
+(* no_retiming = "true" *) reg [6:0] multiregimpl4_regs0 = 7'd0;
+(* no_retiming = "true" *) reg [6:0] multiregimpl4_regs1 = 7'd0;
+(* no_retiming = "true" *) reg [6:0] multiregimpl5_regs0 = 7'd0;
+(* no_retiming = "true" *) reg [6:0] multiregimpl5_regs1 = 7'd0;
 
 always @(*) begin
-	lvds_pads_adc0_d_p <= 8'd0;
-	lvds_pads_adc0_d_p[0] <= adc0[0];
-	lvds_pads_adc0_d_p[1] <= adc0[2];
-	lvds_pads_adc0_d_p[2] <= adc0[4];
-	lvds_pads_adc0_d_p[3] <= adc0[6];
-	lvds_pads_adc0_d_p[4] <= adc0[8];
-	lvds_pads_adc0_d_p[5] <= adc0[10];
-	lvds_pads_adc0_d_p[6] <= adc0[12];
-	lvds_pads_adc0_d_p[7] <= adc0[14];
+	top_record0_lvds_pads_adc_d_p <= 8'd0;
+	top_record0_lvds_pads_adc_d_p[0] <= adc0[0];
+	top_record0_lvds_pads_adc_d_p[1] <= adc0[2];
+	top_record0_lvds_pads_adc_d_p[2] <= adc0[4];
+	top_record0_lvds_pads_adc_d_p[3] <= adc0[6];
+	top_record0_lvds_pads_adc_d_p[4] <= adc0[8];
+	top_record0_lvds_pads_adc_d_p[5] <= adc0[10];
+	top_record0_lvds_pads_adc_d_p[6] <= adc0[12];
+	top_record0_lvds_pads_adc_d_p[7] <= adc0[14];
 end
 always @(*) begin
-	lvds_pads_adc0_d_n <= 8'd0;
-	lvds_pads_adc0_d_n[0] <= adc0[1];
-	lvds_pads_adc0_d_n[1] <= adc0[3];
-	lvds_pads_adc0_d_n[2] <= adc0[5];
-	lvds_pads_adc0_d_n[3] <= adc0[7];
-	lvds_pads_adc0_d_n[4] <= adc0[9];
-	lvds_pads_adc0_d_n[5] <= adc0[11];
-	lvds_pads_adc0_d_n[6] <= adc0[13];
-	lvds_pads_adc0_d_n[7] <= adc0[15];
+	top_record0_lvds_pads_adc_d_n <= 8'd0;
+	top_record0_lvds_pads_adc_d_n[0] <= adc0[1];
+	top_record0_lvds_pads_adc_d_n[1] <= adc0[3];
+	top_record0_lvds_pads_adc_d_n[2] <= adc0[5];
+	top_record0_lvds_pads_adc_d_n[3] <= adc0[7];
+	top_record0_lvds_pads_adc_d_n[4] <= adc0[9];
+	top_record0_lvds_pads_adc_d_n[5] <= adc0[11];
+	top_record0_lvds_pads_adc_d_n[6] <= adc0[13];
+	top_record0_lvds_pads_adc_d_n[7] <= adc0[15];
 end
-assign lvds_pads_adc0_lclk_p = adc0[16];
-assign lvds_pads_adc0_lclk_n = adc0[17];
-assign lvds_pads_adc0_fclk_p = adc0[18];
-assign lvds_pads_adc0_fclk_n = adc0[19];
-assign lvds_adc0_d_clk = adc_axis_clk;
-assign lvds_adc0_d_rst = adc_axis_rst;
-assign adc0_tdata = lvds_adc0_d;
-assign adc0_tvalid = lvds_adc0_d_valid;
-assign lvds_adc0_d_ready = adc0_tready;
-assign data_clk_1 = adc_axis_clk;
-assign data_rst_1 = adc_axis_rst;
+assign top_record0_lvds_pads_adc_lclk_p = adc0[16];
+assign top_record0_lvds_pads_adc_lclk_n = adc0[17];
+assign top_record0_lvds_pads_adc_fclk_p = adc0[18];
+assign top_record0_lvds_pads_adc_fclk_n = adc0[19];
+assign top_lvdsreceiver0_d_clk = adc_axis_clk;
+assign top_lvdsreceiver0_d_rst = adc_axis_rst;
+assign adc0_tdata = top_lvdsreceiver0_d;
+assign adc0_tvalid = top_lvdsreceiver0_d_valid;
+assign top_lvdsreceiver0_d_ready = adc0_tready;
+assign adc0_tlast = top_lvdsreceiver0_d_last;
+always @(*) begin
+	top_record1_lvds_pads_adc_d_p <= 8'd0;
+	top_record1_lvds_pads_adc_d_p[0] <= adc1[0];
+	top_record1_lvds_pads_adc_d_p[1] <= adc1[2];
+	top_record1_lvds_pads_adc_d_p[2] <= adc1[4];
+	top_record1_lvds_pads_adc_d_p[3] <= adc1[6];
+	top_record1_lvds_pads_adc_d_p[4] <= adc1[8];
+	top_record1_lvds_pads_adc_d_p[5] <= adc1[10];
+	top_record1_lvds_pads_adc_d_p[6] <= adc1[12];
+	top_record1_lvds_pads_adc_d_p[7] <= adc1[14];
+end
+always @(*) begin
+	top_record1_lvds_pads_adc_d_n <= 8'd0;
+	top_record1_lvds_pads_adc_d_n[0] <= adc1[1];
+	top_record1_lvds_pads_adc_d_n[1] <= adc1[3];
+	top_record1_lvds_pads_adc_d_n[2] <= adc1[5];
+	top_record1_lvds_pads_adc_d_n[3] <= adc1[7];
+	top_record1_lvds_pads_adc_d_n[4] <= adc1[9];
+	top_record1_lvds_pads_adc_d_n[5] <= adc1[11];
+	top_record1_lvds_pads_adc_d_n[6] <= adc1[13];
+	top_record1_lvds_pads_adc_d_n[7] <= adc1[15];
+end
+assign top_record1_lvds_pads_adc_lclk_p = adc1[16];
+assign top_record1_lvds_pads_adc_lclk_n = adc1[17];
+assign top_record1_lvds_pads_adc_fclk_p = adc1[18];
+assign top_record1_lvds_pads_adc_fclk_n = adc1[19];
 always @(*) begin
 	debug <= 64'd0;
-	debug[31:0] <= lvds_adc0_d;
-	debug[39:32] <= lvds_adc0_fclk_preslip;
-	debug[40] <= lvds_adc0_d_valid;
-	debug[41] <= adc0_tvalid;
-	debug[42] <= adc0_tready;
-	debug[63:45] <= count;
+	debug[31:0] <= top_lvdsreceiver1_d;
+	debug[39:32] <= top_lvdsreceiver1_fclk_preslip;
+	debug[40] <= top_lvdsreceiver1_d_valid;
+	debug[41] <= top_lvdsreceiver1_d_last;
+	debug[42] <= top_lvdsreceiver1_d_ready;
+	debug[63:45] <= top_count;
+end
+assign top_lvdsreceiver1_d_clk = adc_axis_clk;
+assign top_lvdsreceiver1_d_rst = adc_axis_rst;
+assign adc1_tdata = top_lvdsreceiver1_d;
+assign adc1_tvalid = top_lvdsreceiver1_d_valid;
+assign top_lvdsreceiver1_d_ready = adc1_tready;
+assign adc1_tlast = top_lvdsreceiver1_d_last;
+assign data_clk = adc_axis_clk;
+assign data_rst = adc_axis_rst;
+always @(*) begin
+	top_offsetdac_current_dac_word <= 24'd0;
+	top_offsetdac_current_dac_word[15:0] <= rhs_array_muxed;
+	top_offsetdac_current_dac_word[17:16] <= top_offsetdac_pd;
+	top_offsetdac_current_dac_word[23:18] <= 1'd0;
 end
 always @(*) begin
-	offsetdac_current_dac_word <= 24'd0;
-	offsetdac_current_dac_word[15:0] <= rhs_array_muxed;
-	offsetdac_current_dac_word[17:16] <= offsetdac_pd;
-	offsetdac_current_dac_word[23:18] <= 1'd0;
-end
-always @(*) begin
+	top_offsetdac_current_channel_offsetdac_f_next_value <= 3'd0;
+	top_offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd0;
 	offsetdac_next_state <= 1'd0;
-	offsetdac_current_bit_offsetdac_next_value0 <= 5'd0;
-	offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd0;
-	offsetdac_mux_nE_offsetdac_next_value1 <= 1'd0;
-	offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd0;
-	offsetdac_mux_S_offsetdac_t_next_value <= 3'd0;
-	offsetdac_mux_S_offsetdac_t_next_value_ce <= 1'd0;
-	offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd0;
-	offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd0;
-	offsetdac_spi_DIN_offsetdac_next_value3 <= 1'd0;
-	offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd0;
-	offsetdac_current_channel_offsetdac_f_next_value <= 3'd0;
-	offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd0;
+	top_offsetdac_current_bit_offsetdac_next_value0 <= 5'd0;
+	top_offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd0;
+	top_offsetdac_mux_nE_offsetdac_next_value1 <= 1'd0;
+	top_offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd0;
+	top_offsetdac_mux_S_offsetdac_t_next_value <= 3'd0;
+	top_offsetdac_mux_S_offsetdac_t_next_value_ce <= 1'd0;
+	top_offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd0;
+	top_offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd0;
+	top_offsetdac_spi_DIN_offsetdac_next_value3 <= 1'd0;
+	top_offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd0;
 	offsetdac_next_state <= offsetdac_state;
 	case (offsetdac_state)
 		1'd1: begin
-			if (offsetdac_clk_falling) begin
-				offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd0;
-				offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd1;
-				offsetdac_mux_nE_offsetdac_next_value1 <= 1'd0;
-				offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
-				offsetdac_spi_DIN_offsetdac_next_value3 <= cases_array_muxed;
-				offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd1;
-				if ((offsetdac_current_bit == 5'd23)) begin
-					offsetdac_mux_nE_offsetdac_next_value1 <= 1'd1;
-					offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
+			if (top_offsetdac_clk_falling) begin
+				top_offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd0;
+				top_offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd1;
+				top_offsetdac_mux_nE_offsetdac_next_value1 <= 1'd0;
+				top_offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
+				top_offsetdac_spi_DIN_offsetdac_next_value3 <= cases_array_muxed;
+				top_offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd1;
+				if ((top_offsetdac_current_bit == 5'd23)) begin
+					top_offsetdac_mux_nE_offsetdac_next_value1 <= 1'd1;
+					top_offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
 					offsetdac_next_state <= 1'd0;
-					offsetdac_mux_S_offsetdac_t_next_value <= offsetdac_current_channel;
-					offsetdac_mux_S_offsetdac_t_next_value_ce <= 1'd1;
-					offsetdac_current_channel_offsetdac_f_next_value <= (offsetdac_current_channel + 1'd1);
-					offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd1;
+					top_offsetdac_mux_S_offsetdac_t_next_value <= top_offsetdac_current_channel;
+					top_offsetdac_mux_S_offsetdac_t_next_value_ce <= 1'd1;
+					top_offsetdac_current_channel_offsetdac_f_next_value <= (top_offsetdac_current_channel + 1'd1);
+					top_offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd1;
 				end else begin
-					offsetdac_current_bit_offsetdac_next_value0 <= (offsetdac_current_bit + 1'd1);
-					offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd1;
+					top_offsetdac_current_bit_offsetdac_next_value0 <= (top_offsetdac_current_bit + 1'd1);
+					top_offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd1;
 				end
 			end
 		end
 		default: begin
-			if (offsetdac_clk_falling) begin
-				offsetdac_current_bit_offsetdac_next_value0 <= 1'd0;
-				offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd1;
-				offsetdac_mux_nE_offsetdac_next_value1 <= 1'd1;
-				offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
-				offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd1;
-				offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd1;
-				offsetdac_spi_DIN_offsetdac_next_value3 <= 1'd0;
-				offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd1;
-				if (offsetdac_enable_storage[0]) begin
+			if (top_offsetdac_clk_falling) begin
+				top_offsetdac_current_bit_offsetdac_next_value0 <= 1'd0;
+				top_offsetdac_current_bit_offsetdac_next_value_ce0 <= 1'd1;
+				top_offsetdac_mux_nE_offsetdac_next_value1 <= 1'd1;
+				top_offsetdac_mux_nE_offsetdac_next_value_ce1 <= 1'd1;
+				top_offsetdac_spi_nSYNC_offsetdac_next_value2 <= 1'd1;
+				top_offsetdac_spi_nSYNC_offsetdac_next_value_ce2 <= 1'd1;
+				top_offsetdac_spi_DIN_offsetdac_next_value3 <= 1'd0;
+				top_offsetdac_spi_DIN_offsetdac_next_value_ce3 <= 1'd1;
+				if (top_offsetdac_enable_storage[0]) begin
 					offsetdac_next_state <= 1'd1;
 				end else begin
-					offsetdac_current_channel_offsetdac_f_next_value <= 1'd0;
-					offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd1;
+					top_offsetdac_current_channel_offsetdac_f_next_value <= 1'd0;
+					top_offsetdac_current_channel_offsetdac_f_next_value_ce <= 1'd1;
 				end
 			end
 		end
 	endcase
 end
 always @(*) begin
-	lvds_adc0_d_preslip <= 64'd0;
-	lvds_adc0_d_preslip[7:0] <= lvds_adc0_serdes_q0;
-	lvds_adc0_d_preslip[15:8] <= lvds_adc0_serdes_q1;
-	lvds_adc0_d_preslip[23:16] <= lvds_adc0_serdes_q2;
-	lvds_adc0_d_preslip[31:24] <= lvds_adc0_serdes_q3;
-	lvds_adc0_d_preslip[39:32] <= lvds_adc0_serdes_q4;
-	lvds_adc0_d_preslip[47:40] <= lvds_adc0_serdes_q5;
-	lvds_adc0_d_preslip[55:48] <= lvds_adc0_serdes_q6;
-	lvds_adc0_d_preslip[63:56] <= lvds_adc0_serdes_q7;
+	top_lvdsreceiver0_d_preslip <= 64'd0;
+	top_lvdsreceiver0_d_preslip[7:0] <= top_lvdsreceiver0_serdes_q0;
+	top_lvdsreceiver0_d_preslip[15:8] <= top_lvdsreceiver0_serdes_q1;
+	top_lvdsreceiver0_d_preslip[23:16] <= top_lvdsreceiver0_serdes_q2;
+	top_lvdsreceiver0_d_preslip[31:24] <= top_lvdsreceiver0_serdes_q3;
+	top_lvdsreceiver0_d_preslip[39:32] <= top_lvdsreceiver0_serdes_q4;
+	top_lvdsreceiver0_d_preslip[47:40] <= top_lvdsreceiver0_serdes_q5;
+	top_lvdsreceiver0_d_preslip[55:48] <= top_lvdsreceiver0_serdes_q6;
+	top_lvdsreceiver0_d_preslip[63:56] <= top_lvdsreceiver0_serdes_q7;
 end
-assign lvds_adc0_fclk_preslip = lvds_adc0_serdes_q8;
-assign data_clk = lvds_adc0_d_clk;
-assign data_rst = lvds_adc0_d_rst;
-assign lvds_adc0_data_fifo_asyncfifo_we = 1'd1;
-assign lvds_adc0_data_fifo_re = lvds_adc0_d_ready;
-assign lvds_adc0_d = lvds_adc0_data_fifo_dout[63:0];
-assign lvds_adc0_fclk = lvds_adc0_data_fifo_dout[71:64];
-assign lvds_adc0_d_valid = lvds_adc0_data_fifo_readable;
-assign lvds_adc0_data_fifo_asyncfifo_re = (lvds_adc0_data_fifo_re | (~lvds_adc0_data_fifo_readable));
-assign lvds_adc0_data_fifo_graycounter0_ce = (lvds_adc0_data_fifo_asyncfifo_writable & lvds_adc0_data_fifo_asyncfifo_we);
-assign lvds_adc0_data_fifo_graycounter1_ce = (lvds_adc0_data_fifo_asyncfifo_readable & lvds_adc0_data_fifo_asyncfifo_re);
-assign lvds_adc0_data_fifo_asyncfifo_writable = (((lvds_adc0_data_fifo_graycounter0_q[6] == lvds_adc0_data_fifo_consume_wdomain[6]) | (lvds_adc0_data_fifo_graycounter0_q[5] == lvds_adc0_data_fifo_consume_wdomain[5])) | (lvds_adc0_data_fifo_graycounter0_q[4:0] != lvds_adc0_data_fifo_consume_wdomain[4:0]));
-assign lvds_adc0_data_fifo_asyncfifo_readable = (lvds_adc0_data_fifo_graycounter1_q != lvds_adc0_data_fifo_produce_rdomain);
-assign lvds_adc0_data_fifo_wrport_adr = lvds_adc0_data_fifo_graycounter0_q_binary[5:0];
-assign lvds_adc0_data_fifo_wrport_dat_w = lvds_adc0_data_fifo_asyncfifo_din;
-assign lvds_adc0_data_fifo_wrport_we = lvds_adc0_data_fifo_graycounter0_ce;
-assign lvds_adc0_data_fifo_rdport_adr = lvds_adc0_data_fifo_graycounter1_q_next_binary[5:0];
-assign lvds_adc0_data_fifo_asyncfifo_dout = lvds_adc0_data_fifo_rdport_dat_r;
+assign top_lvdsreceiver0_fclk_preslip = top_lvdsreceiver0_serdes_q8;
+assign adcif0_data_clk = top_lvdsreceiver0_d_clk;
+assign adcif0_data_rst = top_lvdsreceiver0_d_rst;
+assign top_lvdsreceiver0_data_fifo_asyncfifo0_we = 1'd1;
+assign top_lvdsreceiver0_data_fifo_re = top_lvdsreceiver0_d_ready;
+assign top_lvdsreceiver0_d = top_lvdsreceiver0_data_fifo_dout[63:0];
+assign top_lvdsreceiver0_fclk = top_lvdsreceiver0_data_fifo_dout[71:64];
+assign top_lvdsreceiver0_d_valid = top_lvdsreceiver0_data_fifo_readable;
+assign top_lvdsreceiver0_d_last = (top_lvdsreceiver0_last_counter == 14'd16383);
+assign top_lvdsreceiver0_data_fifo_asyncfifo0_re = (top_lvdsreceiver0_data_fifo_re | (~top_lvdsreceiver0_data_fifo_readable));
+assign top_lvdsreceiver0_data_fifo_graycounter0_ce = (top_lvdsreceiver0_data_fifo_asyncfifo0_writable & top_lvdsreceiver0_data_fifo_asyncfifo0_we);
+assign top_lvdsreceiver0_data_fifo_graycounter1_ce = (top_lvdsreceiver0_data_fifo_asyncfifo0_readable & top_lvdsreceiver0_data_fifo_asyncfifo0_re);
+assign top_lvdsreceiver0_data_fifo_asyncfifo0_writable = (((top_lvdsreceiver0_data_fifo_graycounter0_q[6] == top_lvdsreceiver0_data_fifo_consume_wdomain[6]) | (top_lvdsreceiver0_data_fifo_graycounter0_q[5] == top_lvdsreceiver0_data_fifo_consume_wdomain[5])) | (top_lvdsreceiver0_data_fifo_graycounter0_q[4:0] != top_lvdsreceiver0_data_fifo_consume_wdomain[4:0]));
+assign top_lvdsreceiver0_data_fifo_asyncfifo0_readable = (top_lvdsreceiver0_data_fifo_graycounter1_q != top_lvdsreceiver0_data_fifo_produce_rdomain);
+assign top_lvdsreceiver0_data_fifo_wrport_adr = top_lvdsreceiver0_data_fifo_graycounter0_q_binary[5:0];
+assign top_lvdsreceiver0_data_fifo_wrport_dat_w = top_lvdsreceiver0_data_fifo_asyncfifo0_din;
+assign top_lvdsreceiver0_data_fifo_wrport_we = top_lvdsreceiver0_data_fifo_graycounter0_ce;
+assign top_lvdsreceiver0_data_fifo_rdport_adr = top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary[5:0];
+assign top_lvdsreceiver0_data_fifo_asyncfifo0_dout = top_lvdsreceiver0_data_fifo_rdport_dat_r;
 always @(*) begin
-	lvds_adc0_data_fifo_graycounter0_q_next_binary <= 7'd0;
-	if (lvds_adc0_data_fifo_graycounter0_ce) begin
-		lvds_adc0_data_fifo_graycounter0_q_next_binary <= (lvds_adc0_data_fifo_graycounter0_q_binary + 1'd1);
+	top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary <= 7'd0;
+	if (top_lvdsreceiver0_data_fifo_graycounter0_ce) begin
+		top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary <= (top_lvdsreceiver0_data_fifo_graycounter0_q_binary + 1'd1);
 	end else begin
-		lvds_adc0_data_fifo_graycounter0_q_next_binary <= lvds_adc0_data_fifo_graycounter0_q_binary;
+		top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary <= top_lvdsreceiver0_data_fifo_graycounter0_q_binary;
 	end
 end
-assign lvds_adc0_data_fifo_graycounter0_q_next = (lvds_adc0_data_fifo_graycounter0_q_next_binary ^ lvds_adc0_data_fifo_graycounter0_q_next_binary[6:1]);
+assign top_lvdsreceiver0_data_fifo_graycounter0_q_next = (top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary ^ top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary[6:1]);
 always @(*) begin
-	lvds_adc0_data_fifo_graycounter1_q_next_binary <= 7'd0;
-	if (lvds_adc0_data_fifo_graycounter1_ce) begin
-		lvds_adc0_data_fifo_graycounter1_q_next_binary <= (lvds_adc0_data_fifo_graycounter1_q_binary + 1'd1);
+	top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary <= 7'd0;
+	if (top_lvdsreceiver0_data_fifo_graycounter1_ce) begin
+		top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary <= (top_lvdsreceiver0_data_fifo_graycounter1_q_binary + 1'd1);
 	end else begin
-		lvds_adc0_data_fifo_graycounter1_q_next_binary <= lvds_adc0_data_fifo_graycounter1_q_binary;
+		top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary <= top_lvdsreceiver0_data_fifo_graycounter1_q_binary;
 	end
 end
-assign lvds_adc0_data_fifo_graycounter1_q_next = (lvds_adc0_data_fifo_graycounter1_q_next_binary ^ lvds_adc0_data_fifo_graycounter1_q_next_binary[6:1]);
-assign write_transaction = (((axi_lite_aw_valid & axi_lite_aw_ready) & axi_lite_w_valid) & axi_lite_w_ready);
-assign read_transaction = (axi_lite_ar_valid & axi_lite_ar_ready);
-assign csr_adr = (addr >>> 2'd2);
-assign csr_dat_w = wdata;
-assign axi_lite_r_data = csr_dat_r;
+assign top_lvdsreceiver0_data_fifo_graycounter1_q_next = (top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary ^ top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary[6:1]);
+always @(*) begin
+	top_lvdsreceiver1_d_preslip <= 64'd0;
+	top_lvdsreceiver1_d_preslip[7:0] <= top_lvdsreceiver1_serdes_q0;
+	top_lvdsreceiver1_d_preslip[15:8] <= top_lvdsreceiver1_serdes_q1;
+	top_lvdsreceiver1_d_preslip[23:16] <= top_lvdsreceiver1_serdes_q2;
+	top_lvdsreceiver1_d_preslip[31:24] <= top_lvdsreceiver1_serdes_q3;
+	top_lvdsreceiver1_d_preslip[39:32] <= top_lvdsreceiver1_serdes_q4;
+	top_lvdsreceiver1_d_preslip[47:40] <= top_lvdsreceiver1_serdes_q5;
+	top_lvdsreceiver1_d_preslip[55:48] <= top_lvdsreceiver1_serdes_q6;
+	top_lvdsreceiver1_d_preslip[63:56] <= top_lvdsreceiver1_serdes_q7;
+end
+assign top_lvdsreceiver1_fclk_preslip = top_lvdsreceiver1_serdes_q8;
+assign adcif1_data_clk = top_lvdsreceiver1_d_clk;
+assign adcif1_data_rst = top_lvdsreceiver1_d_rst;
+assign top_lvdsreceiver1_data_fifo_asyncfifo1_we = 1'd1;
+assign top_lvdsreceiver1_data_fifo_re = top_lvdsreceiver1_d_ready;
+assign top_lvdsreceiver1_d = top_lvdsreceiver1_data_fifo_dout[63:0];
+assign top_lvdsreceiver1_fclk = top_lvdsreceiver1_data_fifo_dout[71:64];
+assign top_lvdsreceiver1_d_valid = top_lvdsreceiver1_data_fifo_readable;
+assign top_lvdsreceiver1_d_last = (top_lvdsreceiver1_last_counter == 14'd16383);
+assign top_lvdsreceiver1_data_fifo_asyncfifo1_re = (top_lvdsreceiver1_data_fifo_re | (~top_lvdsreceiver1_data_fifo_readable));
+assign top_lvdsreceiver1_data_fifo_graycounter2_ce = (top_lvdsreceiver1_data_fifo_asyncfifo1_writable & top_lvdsreceiver1_data_fifo_asyncfifo1_we);
+assign top_lvdsreceiver1_data_fifo_graycounter3_ce = (top_lvdsreceiver1_data_fifo_asyncfifo1_readable & top_lvdsreceiver1_data_fifo_asyncfifo1_re);
+assign top_lvdsreceiver1_data_fifo_asyncfifo1_writable = (((top_lvdsreceiver1_data_fifo_graycounter2_q[6] == top_lvdsreceiver1_data_fifo_consume_wdomain[6]) | (top_lvdsreceiver1_data_fifo_graycounter2_q[5] == top_lvdsreceiver1_data_fifo_consume_wdomain[5])) | (top_lvdsreceiver1_data_fifo_graycounter2_q[4:0] != top_lvdsreceiver1_data_fifo_consume_wdomain[4:0]));
+assign top_lvdsreceiver1_data_fifo_asyncfifo1_readable = (top_lvdsreceiver1_data_fifo_graycounter3_q != top_lvdsreceiver1_data_fifo_produce_rdomain);
+assign top_lvdsreceiver1_data_fifo_wrport_adr = top_lvdsreceiver1_data_fifo_graycounter2_q_binary[5:0];
+assign top_lvdsreceiver1_data_fifo_wrport_dat_w = top_lvdsreceiver1_data_fifo_asyncfifo1_din;
+assign top_lvdsreceiver1_data_fifo_wrport_we = top_lvdsreceiver1_data_fifo_graycounter2_ce;
+assign top_lvdsreceiver1_data_fifo_rdport_adr = top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary[5:0];
+assign top_lvdsreceiver1_data_fifo_asyncfifo1_dout = top_lvdsreceiver1_data_fifo_rdport_dat_r;
+always @(*) begin
+	top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary <= 7'd0;
+	if (top_lvdsreceiver1_data_fifo_graycounter2_ce) begin
+		top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary <= (top_lvdsreceiver1_data_fifo_graycounter2_q_binary + 1'd1);
+	end else begin
+		top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary <= top_lvdsreceiver1_data_fifo_graycounter2_q_binary;
+	end
+end
+assign top_lvdsreceiver1_data_fifo_graycounter2_q_next = (top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary ^ top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary[6:1]);
+always @(*) begin
+	top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary <= 7'd0;
+	if (top_lvdsreceiver1_data_fifo_graycounter3_ce) begin
+		top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary <= (top_lvdsreceiver1_data_fifo_graycounter3_q_binary + 1'd1);
+	end else begin
+		top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary <= top_lvdsreceiver1_data_fifo_graycounter3_q_binary;
+	end
+end
+assign top_lvdsreceiver1_data_fifo_graycounter3_q_next = (top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary ^ top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary[6:1]);
+assign top_write_transaction = (((axi_lite_aw_valid & axi_lite_aw_ready) & axi_lite_w_valid) & axi_lite_w_ready);
+assign top_read_transaction = (axi_lite_ar_valid & axi_lite_ar_ready);
+assign top_csr_adr = (top_addr >>> 2'd2);
+assign top_csr_dat_w = top_wdata;
+assign axi_lite_r_data = top_csr_dat_r;
 assign axi_lite_r_resp = 1'd0;
-assign busy = (~is_ongoing0);
-assign axi_lite_r_valid = is_ongoing1;
-assign csr_we = is_ongoing2;
+assign top_busy = (~top_is_ongoing0);
+assign axi_lite_r_valid = top_is_ongoing1;
+assign top_csr_we = top_is_ongoing2;
 always @(*) begin
-	addr <= 16'd0;
-	is_ongoing2 <= 1'd0;
-	is_ongoing0 <= 1'd0;
 	axilite2csr_next_state <= 2'd0;
-	is_ongoing1 <= 1'd0;
-	wdata_axilite2csr_next_value <= 32'd0;
-	wdata_axilite2csr_next_value_ce <= 1'd0;
+	top_wdata_axilite2csr_next_value <= 32'd0;
+	top_is_ongoing1 <= 1'd0;
+	top_wdata_axilite2csr_next_value_ce <= 1'd0;
+	top_is_ongoing2 <= 1'd0;
+	top_addr <= 16'd0;
+	top_is_ongoing0 <= 1'd0;
 	axilite2csr_next_state <= axilite2csr_state;
 	case (axilite2csr_state)
 		1'd1: begin
-			is_ongoing1 <= 1'd1;
-			addr <= axi_lite_ar_addr;
+			top_is_ongoing1 <= 1'd1;
+			top_addr <= axi_lite_ar_addr;
 			if (axi_lite_r_ready) begin
 				axilite2csr_next_state <= 1'd0;
 			end
 		end
 		2'd2: begin
-			is_ongoing2 <= 1'd1;
-			addr <= axi_lite_aw_addr;
+			top_is_ongoing2 <= 1'd1;
+			top_addr <= axi_lite_aw_addr;
 			axilite2csr_next_state <= 1'd0;
 		end
 		default: begin
-			is_ongoing0 <= 1'd1;
-			if (read_transaction) begin
-				addr <= axi_lite_ar_addr;
+			top_is_ongoing0 <= 1'd1;
+			if (top_read_transaction) begin
+				top_addr <= axi_lite_ar_addr;
 				axilite2csr_next_state <= 1'd1;
 			end else begin
-				if (write_transaction) begin
-					addr <= axi_lite_aw_addr;
-					wdata_axilite2csr_next_value <= axi_lite_w_data;
-					wdata_axilite2csr_next_value_ce <= 1'd1;
+				if (top_write_transaction) begin
+					top_addr <= axi_lite_aw_addr;
+					top_wdata_axilite2csr_next_value <= axi_lite_w_data;
+					top_wdata_axilite2csr_next_value_ce <= 1'd1;
 					axilite2csr_next_state <= 2'd2;
 				end
 			end
 		end
 	endcase
 end
-assign csrbank0_sel = (interface0_bank_bus_adr[13:9] == 1'd0);
-assign csrbank0_status_r = interface0_bank_bus_dat_w[31:0];
-assign csrbank0_status_re = ((csrbank0_sel & interface0_bank_bus_we) & (interface0_bank_bus_adr[0] == 1'd0));
-assign csrbank0_control0_r = interface0_bank_bus_dat_w[31:0];
-assign csrbank0_control0_re = ((csrbank0_sel & interface0_bank_bus_we) & (interface0_bank_bus_adr[0] == 1'd1));
-assign csrbank0_status_w = lvds_adc0_status[31:0];
-assign lvds_adc0_control_storage = lvds_adc0_control_storage_full[31:0];
-assign csrbank0_control0_w = lvds_adc0_control_storage_full[31:0];
-assign csrbank1_sel = (interface1_bank_bus_adr[13:9] == 1'd1);
-assign csrbank1_status_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_status_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 1'd0));
-assign csrbank1_control0_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_control0_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 1'd1));
-assign csrbank1_clkdiv0_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_clkdiv0_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 2'd2));
-assign csrbank1_enable0_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_enable0_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 2'd3));
-assign csrbank1_v00_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v00_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 3'd4));
-assign csrbank1_v10_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v10_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 3'd5));
-assign csrbank1_v20_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v20_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 3'd6));
-assign csrbank1_v30_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v30_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 3'd7));
-assign csrbank1_v40_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v40_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 4'd8));
-assign csrbank1_v50_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v50_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 4'd9));
-assign csrbank1_v60_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v60_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 4'd10));
-assign csrbank1_v70_r = interface1_bank_bus_dat_w[31:0];
-assign csrbank1_v70_re = ((csrbank1_sel & interface1_bank_bus_we) & (interface1_bank_bus_adr[3:0] == 4'd11));
-assign csrbank1_status_w = offsetdac_status[31:0];
-assign offsetdac_control_storage = offsetdac_control_storage_full[31:0];
-assign csrbank1_control0_w = offsetdac_control_storage_full[31:0];
-assign offsetdac_clkdiv_storage = offsetdac_clkdiv_storage_full[31:0];
-assign csrbank1_clkdiv0_w = offsetdac_clkdiv_storage_full[31:0];
-assign offsetdac_enable_storage = offsetdac_enable_storage_full[31:0];
-assign csrbank1_enable0_w = offsetdac_enable_storage_full[31:0];
-assign offsetdac_v0_storage = offsetdac_v0_storage_full[31:0];
-assign csrbank1_v00_w = offsetdac_v0_storage_full[31:0];
-assign offsetdac_v1_storage = offsetdac_v1_storage_full[31:0];
-assign csrbank1_v10_w = offsetdac_v1_storage_full[31:0];
-assign offsetdac_v2_storage = offsetdac_v2_storage_full[31:0];
-assign csrbank1_v20_w = offsetdac_v2_storage_full[31:0];
-assign offsetdac_v3_storage = offsetdac_v3_storage_full[31:0];
-assign csrbank1_v30_w = offsetdac_v3_storage_full[31:0];
-assign offsetdac_v4_storage = offsetdac_v4_storage_full[31:0];
-assign csrbank1_v40_w = offsetdac_v4_storage_full[31:0];
-assign offsetdac_v5_storage = offsetdac_v5_storage_full[31:0];
-assign csrbank1_v50_w = offsetdac_v5_storage_full[31:0];
-assign offsetdac_v6_storage = offsetdac_v6_storage_full[31:0];
-assign csrbank1_v60_w = offsetdac_v6_storage_full[31:0];
-assign offsetdac_v7_storage = offsetdac_v7_storage_full[31:0];
-assign csrbank1_v70_w = offsetdac_v7_storage_full[31:0];
-assign interface0_bank_bus_adr = csr_adr;
-assign interface1_bank_bus_adr = csr_adr;
-assign interface0_bank_bus_we = csr_we;
-assign interface1_bank_bus_we = csr_we;
-assign interface0_bank_bus_dat_w = csr_dat_w;
-assign interface1_bank_bus_dat_w = csr_dat_w;
-assign csr_dat_r = (interface0_bank_bus_dat_r | interface1_bank_bus_dat_r);
+assign top_csrbank0_sel = (top_interface0_bank_bus_adr[13:9] == 1'd0);
+assign top_csrbank0_status_r = top_interface0_bank_bus_dat_w[31:0];
+assign top_csrbank0_status_re = ((top_csrbank0_sel & top_interface0_bank_bus_we) & (top_interface0_bank_bus_adr[0] == 1'd0));
+assign top_csrbank0_control0_r = top_interface0_bank_bus_dat_w[31:0];
+assign top_csrbank0_control0_re = ((top_csrbank0_sel & top_interface0_bank_bus_we) & (top_interface0_bank_bus_adr[0] == 1'd1));
+assign top_csrbank0_status_w = top_lvdsreceiver0_status[31:0];
+assign top_lvdsreceiver0_control_storage = top_lvdsreceiver0_control_storage_full[31:0];
+assign top_csrbank0_control0_w = top_lvdsreceiver0_control_storage_full[31:0];
+assign top_csrbank1_sel = (top_interface1_bank_bus_adr[13:9] == 1'd1);
+assign top_csrbank1_status_r = top_interface1_bank_bus_dat_w[31:0];
+assign top_csrbank1_status_re = ((top_csrbank1_sel & top_interface1_bank_bus_we) & (top_interface1_bank_bus_adr[0] == 1'd0));
+assign top_csrbank1_control0_r = top_interface1_bank_bus_dat_w[31:0];
+assign top_csrbank1_control0_re = ((top_csrbank1_sel & top_interface1_bank_bus_we) & (top_interface1_bank_bus_adr[0] == 1'd1));
+assign top_csrbank1_status_w = top_lvdsreceiver1_status[31:0];
+assign top_lvdsreceiver1_control_storage = top_lvdsreceiver1_control_storage_full[31:0];
+assign top_csrbank1_control0_w = top_lvdsreceiver1_control_storage_full[31:0];
+assign top_csrbank2_sel = (top_interface2_bank_bus_adr[13:9] == 2'd2);
+assign top_csrbank2_status_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_status_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 1'd0));
+assign top_csrbank2_control0_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_control0_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 1'd1));
+assign top_csrbank2_clkdiv0_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_clkdiv0_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 2'd2));
+assign top_csrbank2_enable0_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_enable0_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 2'd3));
+assign top_csrbank2_v00_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v00_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 3'd4));
+assign top_csrbank2_v10_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v10_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 3'd5));
+assign top_csrbank2_v20_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v20_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 3'd6));
+assign top_csrbank2_v30_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v30_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 3'd7));
+assign top_csrbank2_v40_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v40_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 4'd8));
+assign top_csrbank2_v50_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v50_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 4'd9));
+assign top_csrbank2_v60_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v60_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 4'd10));
+assign top_csrbank2_v70_r = top_interface2_bank_bus_dat_w[31:0];
+assign top_csrbank2_v70_re = ((top_csrbank2_sel & top_interface2_bank_bus_we) & (top_interface2_bank_bus_adr[3:0] == 4'd11));
+assign top_csrbank2_status_w = top_offsetdac_status[31:0];
+assign top_offsetdac_control_storage = top_offsetdac_control_storage_full[31:0];
+assign top_csrbank2_control0_w = top_offsetdac_control_storage_full[31:0];
+assign top_offsetdac_clkdiv_storage = top_offsetdac_clkdiv_storage_full[31:0];
+assign top_csrbank2_clkdiv0_w = top_offsetdac_clkdiv_storage_full[31:0];
+assign top_offsetdac_enable_storage = top_offsetdac_enable_storage_full[31:0];
+assign top_csrbank2_enable0_w = top_offsetdac_enable_storage_full[31:0];
+assign top_offsetdac_v0_storage = top_offsetdac_v0_storage_full[31:0];
+assign top_csrbank2_v00_w = top_offsetdac_v0_storage_full[31:0];
+assign top_offsetdac_v1_storage = top_offsetdac_v1_storage_full[31:0];
+assign top_csrbank2_v10_w = top_offsetdac_v1_storage_full[31:0];
+assign top_offsetdac_v2_storage = top_offsetdac_v2_storage_full[31:0];
+assign top_csrbank2_v20_w = top_offsetdac_v2_storage_full[31:0];
+assign top_offsetdac_v3_storage = top_offsetdac_v3_storage_full[31:0];
+assign top_csrbank2_v30_w = top_offsetdac_v3_storage_full[31:0];
+assign top_offsetdac_v4_storage = top_offsetdac_v4_storage_full[31:0];
+assign top_csrbank2_v40_w = top_offsetdac_v4_storage_full[31:0];
+assign top_offsetdac_v5_storage = top_offsetdac_v5_storage_full[31:0];
+assign top_csrbank2_v50_w = top_offsetdac_v5_storage_full[31:0];
+assign top_offsetdac_v6_storage = top_offsetdac_v6_storage_full[31:0];
+assign top_csrbank2_v60_w = top_offsetdac_v6_storage_full[31:0];
+assign top_offsetdac_v7_storage = top_offsetdac_v7_storage_full[31:0];
+assign top_csrbank2_v70_w = top_offsetdac_v7_storage_full[31:0];
+assign top_interface0_bank_bus_adr = top_csr_adr;
+assign top_interface1_bank_bus_adr = top_csr_adr;
+assign top_interface2_bank_bus_adr = top_csr_adr;
+assign top_interface0_bank_bus_we = top_csr_we;
+assign top_interface1_bank_bus_we = top_csr_we;
+assign top_interface2_bank_bus_we = top_csr_we;
+assign top_interface0_bank_bus_dat_w = top_csr_dat_w;
+assign top_interface1_bank_bus_dat_w = top_csr_dat_w;
+assign top_interface2_bank_bus_dat_w = top_csr_dat_w;
+assign top_csr_dat_r = ((top_interface0_bank_bus_dat_r | top_interface1_bank_bus_dat_r) | top_interface2_bank_bus_dat_r);
 always @(*) begin
 	rhs_array_muxed <= 16'd0;
-	case (offsetdac_current_channel)
+	case (top_offsetdac_current_channel)
 		1'd0: begin
-			rhs_array_muxed <= offsetdac_v0_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v0_storage[15:0];
 		end
 		1'd1: begin
-			rhs_array_muxed <= offsetdac_v1_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v1_storage[15:0];
 		end
 		2'd2: begin
-			rhs_array_muxed <= offsetdac_v2_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v2_storage[15:0];
 		end
 		2'd3: begin
-			rhs_array_muxed <= offsetdac_v3_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v3_storage[15:0];
 		end
 		3'd4: begin
-			rhs_array_muxed <= offsetdac_v4_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v4_storage[15:0];
 		end
 		3'd5: begin
-			rhs_array_muxed <= offsetdac_v5_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v5_storage[15:0];
 		end
 		3'd6: begin
-			rhs_array_muxed <= offsetdac_v6_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v6_storage[15:0];
 		end
 		default: begin
-			rhs_array_muxed <= offsetdac_v7_storage[15:0];
+			rhs_array_muxed <= top_offsetdac_v7_storage[15:0];
 		end
 	endcase
 end
 always @(*) begin
 	cases_array_muxed <= 1'd0;
-	case ((5'd23 - offsetdac_current_bit))
+	case ((5'd23 - top_offsetdac_current_bit))
 		1'd0: begin
-			cases_array_muxed <= offsetdac_current_dac_word[0];
+			cases_array_muxed <= top_offsetdac_current_dac_word[0];
 		end
 		1'd1: begin
-			cases_array_muxed <= offsetdac_current_dac_word[1];
+			cases_array_muxed <= top_offsetdac_current_dac_word[1];
 		end
 		2'd2: begin
-			cases_array_muxed <= offsetdac_current_dac_word[2];
+			cases_array_muxed <= top_offsetdac_current_dac_word[2];
 		end
 		2'd3: begin
-			cases_array_muxed <= offsetdac_current_dac_word[3];
+			cases_array_muxed <= top_offsetdac_current_dac_word[3];
 		end
 		3'd4: begin
-			cases_array_muxed <= offsetdac_current_dac_word[4];
+			cases_array_muxed <= top_offsetdac_current_dac_word[4];
 		end
 		3'd5: begin
-			cases_array_muxed <= offsetdac_current_dac_word[5];
+			cases_array_muxed <= top_offsetdac_current_dac_word[5];
 		end
 		3'd6: begin
-			cases_array_muxed <= offsetdac_current_dac_word[6];
+			cases_array_muxed <= top_offsetdac_current_dac_word[6];
 		end
 		3'd7: begin
-			cases_array_muxed <= offsetdac_current_dac_word[7];
+			cases_array_muxed <= top_offsetdac_current_dac_word[7];
 		end
 		4'd8: begin
-			cases_array_muxed <= offsetdac_current_dac_word[8];
+			cases_array_muxed <= top_offsetdac_current_dac_word[8];
 		end
 		4'd9: begin
-			cases_array_muxed <= offsetdac_current_dac_word[9];
+			cases_array_muxed <= top_offsetdac_current_dac_word[9];
 		end
 		4'd10: begin
-			cases_array_muxed <= offsetdac_current_dac_word[10];
+			cases_array_muxed <= top_offsetdac_current_dac_word[10];
 		end
 		4'd11: begin
-			cases_array_muxed <= offsetdac_current_dac_word[11];
+			cases_array_muxed <= top_offsetdac_current_dac_word[11];
 		end
 		4'd12: begin
-			cases_array_muxed <= offsetdac_current_dac_word[12];
+			cases_array_muxed <= top_offsetdac_current_dac_word[12];
 		end
 		4'd13: begin
-			cases_array_muxed <= offsetdac_current_dac_word[13];
+			cases_array_muxed <= top_offsetdac_current_dac_word[13];
 		end
 		4'd14: begin
-			cases_array_muxed <= offsetdac_current_dac_word[14];
+			cases_array_muxed <= top_offsetdac_current_dac_word[14];
 		end
 		4'd15: begin
-			cases_array_muxed <= offsetdac_current_dac_word[15];
+			cases_array_muxed <= top_offsetdac_current_dac_word[15];
 		end
 		5'd16: begin
-			cases_array_muxed <= offsetdac_current_dac_word[16];
+			cases_array_muxed <= top_offsetdac_current_dac_word[16];
 		end
 		5'd17: begin
-			cases_array_muxed <= offsetdac_current_dac_word[17];
+			cases_array_muxed <= top_offsetdac_current_dac_word[17];
 		end
 		5'd18: begin
-			cases_array_muxed <= offsetdac_current_dac_word[18];
+			cases_array_muxed <= top_offsetdac_current_dac_word[18];
 		end
 		5'd19: begin
-			cases_array_muxed <= offsetdac_current_dac_word[19];
+			cases_array_muxed <= top_offsetdac_current_dac_word[19];
 		end
 		5'd20: begin
-			cases_array_muxed <= offsetdac_current_dac_word[20];
+			cases_array_muxed <= top_offsetdac_current_dac_word[20];
 		end
 		5'd21: begin
-			cases_array_muxed <= offsetdac_current_dac_word[21];
+			cases_array_muxed <= top_offsetdac_current_dac_word[21];
 		end
 		5'd22: begin
-			cases_array_muxed <= offsetdac_current_dac_word[22];
+			cases_array_muxed <= top_offsetdac_current_dac_word[22];
 		end
 		default: begin
-			cases_array_muxed <= offsetdac_current_dac_word[23];
+			cases_array_muxed <= top_offsetdac_current_dac_word[23];
 		end
 	endcase
 end
-assign lclkdiv_rst = multiregimpl0_regs1;
-assign lvds_adc0_data_fifo_produce_rdomain = multiregimpl1_regs1;
-assign lvds_adc0_data_fifo_consume_wdomain = multiregimpl2_regs1;
+assign adcif0_lclkdiv_rst = multiregimpl0_regs1;
+assign top_lvdsreceiver0_data_fifo_produce_rdomain = multiregimpl1_regs1;
+assign top_lvdsreceiver0_data_fifo_consume_wdomain = multiregimpl2_regs1;
+assign adcif1_lclkdiv_rst = multiregimpl3_regs1;
+assign top_lvdsreceiver1_data_fifo_produce_rdomain = multiregimpl4_regs1;
+assign top_lvdsreceiver1_data_fifo_consume_wdomain = multiregimpl5_regs1;
 
-always @(posedge data_clk_1) begin
-	count <= (count + 1'd1);
-	if ((lvds_adc0_data_fifo_re | (~lvds_adc0_data_fifo_readable))) begin
-		lvds_adc0_data_fifo_dout <= lvds_adc0_data_fifo_asyncfifo_dout;
-		lvds_adc0_data_fifo_readable <= lvds_adc0_data_fifo_asyncfifo_readable;
+always @(posedge adcif0_data_clk) begin
+	if ((top_lvdsreceiver0_data_fifo_re | (~top_lvdsreceiver0_data_fifo_readable))) begin
+		top_lvdsreceiver0_data_fifo_dout <= top_lvdsreceiver0_data_fifo_asyncfifo0_dout;
+		top_lvdsreceiver0_data_fifo_readable <= top_lvdsreceiver0_data_fifo_asyncfifo0_readable;
 	end
-	lvds_adc0_data_fifo_graycounter1_q_binary <= lvds_adc0_data_fifo_graycounter1_q_next_binary;
-	lvds_adc0_data_fifo_graycounter1_q <= lvds_adc0_data_fifo_graycounter1_q_next;
-	if (data_rst_1) begin
-		lvds_adc0_data_fifo_readable <= 1'd0;
-		lvds_adc0_data_fifo_dout <= 72'd0;
-		lvds_adc0_data_fifo_graycounter1_q <= 7'd0;
-		lvds_adc0_data_fifo_graycounter1_q_binary <= 7'd0;
-		count <= 20'd0;
+	top_lvdsreceiver0_data_fifo_graycounter1_q_binary <= top_lvdsreceiver0_data_fifo_graycounter1_q_next_binary;
+	top_lvdsreceiver0_data_fifo_graycounter1_q <= top_lvdsreceiver0_data_fifo_graycounter1_q_next;
+	if (adcif0_data_rst) begin
+		top_lvdsreceiver0_data_fifo_readable <= 1'd0;
+		top_lvdsreceiver0_data_fifo_graycounter1_q <= 7'd0;
+		top_lvdsreceiver0_data_fifo_graycounter1_q_binary <= 7'd0;
 	end
-	multiregimpl1_regs0 <= lvds_adc0_data_fifo_graycounter0_q;
+	multiregimpl1_regs0 <= top_lvdsreceiver0_data_fifo_graycounter0_q;
 	multiregimpl1_regs1 <= multiregimpl1_regs0;
 end
 
-always @(posedge lclkdiv_clk) begin
-	lvds_adc0_data_fifo_asyncfifo_din[7:0] <= lvds_adc0_d_preslip[7:0];
-	lvds_adc0_data_fifo_asyncfifo_din[15:8] <= lvds_adc0_d_preslip[15:8];
-	lvds_adc0_data_fifo_asyncfifo_din[23:16] <= lvds_adc0_d_preslip[23:16];
-	lvds_adc0_data_fifo_asyncfifo_din[31:24] <= lvds_adc0_d_preslip[31:24];
-	lvds_adc0_data_fifo_asyncfifo_din[39:32] <= lvds_adc0_d_preslip[39:32];
-	lvds_adc0_data_fifo_asyncfifo_din[47:40] <= lvds_adc0_d_preslip[47:40];
-	lvds_adc0_data_fifo_asyncfifo_din[55:48] <= lvds_adc0_d_preslip[55:48];
-	lvds_adc0_data_fifo_asyncfifo_din[63:56] <= lvds_adc0_d_preslip[63:56];
-	lvds_adc0_data_fifo_asyncfifo_din[71:64] <= lvds_adc0_fclk_preslip;
-	lvds_adc0_bitslip_delay <= (lvds_adc0_bitslip_delay + 1'd1);
-	lvds_adc0_bitslip_do <= ((((lvds_adc0_fclk_preslip != 4'd15) & (lvds_adc0_fclk_preslip != 6'd51)) & (lvds_adc0_fclk_preslip != 7'd85)) & (lvds_adc0_bitslip_delay == 1'd0));
-	lvds_adc0_data_fifo_graycounter0_q_binary <= lvds_adc0_data_fifo_graycounter0_q_next_binary;
-	lvds_adc0_data_fifo_graycounter0_q <= lvds_adc0_data_fifo_graycounter0_q_next;
-	if (lclkdiv_rst) begin
-		lvds_adc0_bitslip_do <= 1'd0;
-		lvds_adc0_data_fifo_asyncfifo_din <= 72'd0;
-		lvds_adc0_data_fifo_graycounter0_q <= 7'd0;
-		lvds_adc0_data_fifo_graycounter0_q_binary <= 7'd0;
-		lvds_adc0_bitslip_delay <= 16'd0;
+always @(posedge adcif0_lclkdiv_clk) begin
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[7:0] <= top_lvdsreceiver0_d_preslip[7:0];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[15:8] <= top_lvdsreceiver0_d_preslip[15:8];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[23:16] <= top_lvdsreceiver0_d_preslip[23:16];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[31:24] <= top_lvdsreceiver0_d_preslip[31:24];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[39:32] <= top_lvdsreceiver0_d_preslip[39:32];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[47:40] <= top_lvdsreceiver0_d_preslip[47:40];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[55:48] <= top_lvdsreceiver0_d_preslip[55:48];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[63:56] <= top_lvdsreceiver0_d_preslip[63:56];
+	top_lvdsreceiver0_data_fifo_asyncfifo0_din[71:64] <= top_lvdsreceiver0_fclk_preslip;
+	top_lvdsreceiver0_bitslip_delay <= (top_lvdsreceiver0_bitslip_delay + 1'd1);
+	top_lvdsreceiver0_bitslip_do <= ((((top_lvdsreceiver0_fclk_preslip != 4'd15) & (top_lvdsreceiver0_fclk_preslip != 6'd51)) & (top_lvdsreceiver0_fclk_preslip != 7'd85)) & (top_lvdsreceiver0_bitslip_delay == 1'd0));
+	top_lvdsreceiver0_data_fifo_graycounter0_q_binary <= top_lvdsreceiver0_data_fifo_graycounter0_q_next_binary;
+	top_lvdsreceiver0_data_fifo_graycounter0_q <= top_lvdsreceiver0_data_fifo_graycounter0_q_next;
+	if (adcif0_lclkdiv_rst) begin
+		top_lvdsreceiver0_bitslip_do <= 1'd0;
+		top_lvdsreceiver0_data_fifo_graycounter0_q <= 7'd0;
+		top_lvdsreceiver0_data_fifo_graycounter0_q_binary <= 7'd0;
+		top_lvdsreceiver0_bitslip_delay <= 16'd0;
 	end
-	multiregimpl0_regs0 <= lvds_adc0_control_storage[0];
+	multiregimpl0_regs0 <= top_lvdsreceiver0_control_storage[0];
 	multiregimpl0_regs1 <= multiregimpl0_regs0;
-	multiregimpl2_regs0 <= lvds_adc0_data_fifo_graycounter1_q;
+	multiregimpl2_regs0 <= top_lvdsreceiver0_data_fifo_graycounter1_q;
 	multiregimpl2_regs1 <= multiregimpl2_regs0;
 end
 
+always @(posedge adcif1_data_clk) begin
+	if ((top_lvdsreceiver1_data_fifo_re | (~top_lvdsreceiver1_data_fifo_readable))) begin
+		top_lvdsreceiver1_data_fifo_dout <= top_lvdsreceiver1_data_fifo_asyncfifo1_dout;
+		top_lvdsreceiver1_data_fifo_readable <= top_lvdsreceiver1_data_fifo_asyncfifo1_readable;
+	end
+	top_lvdsreceiver1_data_fifo_graycounter3_q_binary <= top_lvdsreceiver1_data_fifo_graycounter3_q_next_binary;
+	top_lvdsreceiver1_data_fifo_graycounter3_q <= top_lvdsreceiver1_data_fifo_graycounter3_q_next;
+	if (adcif1_data_rst) begin
+		top_lvdsreceiver1_data_fifo_readable <= 1'd0;
+		top_lvdsreceiver1_data_fifo_graycounter3_q <= 7'd0;
+		top_lvdsreceiver1_data_fifo_graycounter3_q_binary <= 7'd0;
+	end
+	multiregimpl4_regs0 <= top_lvdsreceiver1_data_fifo_graycounter2_q;
+	multiregimpl4_regs1 <= multiregimpl4_regs0;
+end
+
+always @(posedge adcif1_lclkdiv_clk) begin
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[7:0] <= top_lvdsreceiver1_d_preslip[7:0];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[15:8] <= top_lvdsreceiver1_d_preslip[15:8];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[23:16] <= top_lvdsreceiver1_d_preslip[23:16];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[31:24] <= top_lvdsreceiver1_d_preslip[31:24];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[39:32] <= top_lvdsreceiver1_d_preslip[39:32];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[47:40] <= top_lvdsreceiver1_d_preslip[47:40];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[55:48] <= top_lvdsreceiver1_d_preslip[55:48];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[63:56] <= top_lvdsreceiver1_d_preslip[63:56];
+	top_lvdsreceiver1_data_fifo_asyncfifo1_din[71:64] <= top_lvdsreceiver1_fclk_preslip;
+	top_lvdsreceiver1_bitslip_delay <= (top_lvdsreceiver1_bitslip_delay + 1'd1);
+	top_lvdsreceiver1_bitslip_do <= ((((top_lvdsreceiver1_fclk_preslip != 4'd15) & (top_lvdsreceiver1_fclk_preslip != 6'd51)) & (top_lvdsreceiver1_fclk_preslip != 7'd85)) & (top_lvdsreceiver1_bitslip_delay == 1'd0));
+	top_lvdsreceiver1_data_fifo_graycounter2_q_binary <= top_lvdsreceiver1_data_fifo_graycounter2_q_next_binary;
+	top_lvdsreceiver1_data_fifo_graycounter2_q <= top_lvdsreceiver1_data_fifo_graycounter2_q_next;
+	if (adcif1_lclkdiv_rst) begin
+		top_lvdsreceiver1_bitslip_do <= 1'd0;
+		top_lvdsreceiver1_data_fifo_graycounter2_q <= 7'd0;
+		top_lvdsreceiver1_data_fifo_graycounter2_q_binary <= 7'd0;
+		top_lvdsreceiver1_bitslip_delay <= 16'd0;
+	end
+	multiregimpl3_regs0 <= top_lvdsreceiver1_control_storage[0];
+	multiregimpl3_regs1 <= multiregimpl3_regs0;
+	multiregimpl5_regs0 <= top_lvdsreceiver1_data_fifo_graycounter3_q;
+	multiregimpl5_regs1 <= multiregimpl5_regs0;
+end
+
+always @(posedge data_clk) begin
+	top_count <= (top_count + 1'd1);
+	if (data_rst) begin
+		top_count <= 20'd0;
+	end
+end
+
 always @(posedge sys_clk) begin
-	if ((offsetdac_clkdiv == offsetdac_clkdiv_storage[15:0])) begin
-		offsetdac_clkdiv <= 1'd0;
+	if ((top_offsetdac_clkdiv == top_offsetdac_clkdiv_storage[15:0])) begin
+		top_offsetdac_clkdiv <= 1'd0;
 	end else begin
-		offsetdac_clkdiv <= (offsetdac_clkdiv + 1'd1);
+		top_offsetdac_clkdiv <= (top_offsetdac_clkdiv + 1'd1);
 	end
-	offsetdac_clk_falling <= 1'd0;
-	if ((offsetdac_clkdiv == 1'd0)) begin
-		offsetdac_clk <= (~offsetdac_clk);
-		offsetdac_clk_falling <= (~offsetdac_clk);
+	top_offsetdac_clk_falling <= 1'd0;
+	if ((top_offsetdac_clkdiv == 1'd0)) begin
+		top_offsetdac_clk <= (~top_offsetdac_clk);
+		top_offsetdac_clk_falling <= (~top_offsetdac_clk);
 	end
-	spi_SCLK <= (offsetdac_clk & offsetdac_enable_storage[0]);
+	spi_SCLK <= (top_offsetdac_clk & top_offsetdac_enable_storage[0]);
 	offsetdac_state <= offsetdac_next_state;
-	if (offsetdac_current_bit_offsetdac_next_value_ce0) begin
-		offsetdac_current_bit <= offsetdac_current_bit_offsetdac_next_value0;
+	if (top_offsetdac_current_bit_offsetdac_next_value_ce0) begin
+		top_offsetdac_current_bit <= top_offsetdac_current_bit_offsetdac_next_value0;
 	end
-	if (offsetdac_mux_nE_offsetdac_next_value_ce1) begin
-		mux_nE <= offsetdac_mux_nE_offsetdac_next_value1;
+	if (top_offsetdac_mux_nE_offsetdac_next_value_ce1) begin
+		mux_nE <= top_offsetdac_mux_nE_offsetdac_next_value1;
 	end
-	if (offsetdac_spi_nSYNC_offsetdac_next_value_ce2) begin
-		spi_nSYNC <= offsetdac_spi_nSYNC_offsetdac_next_value2;
+	if (top_offsetdac_spi_nSYNC_offsetdac_next_value_ce2) begin
+		spi_nSYNC <= top_offsetdac_spi_nSYNC_offsetdac_next_value2;
 	end
-	if (offsetdac_spi_DIN_offsetdac_next_value_ce3) begin
-		spi_DIN <= offsetdac_spi_DIN_offsetdac_next_value3;
+	if (top_offsetdac_spi_DIN_offsetdac_next_value_ce3) begin
+		spi_DIN <= top_offsetdac_spi_DIN_offsetdac_next_value3;
 	end
-	if (offsetdac_current_channel_offsetdac_f_next_value_ce) begin
-		offsetdac_current_channel <= offsetdac_current_channel_offsetdac_f_next_value;
+	if (top_offsetdac_current_channel_offsetdac_f_next_value_ce) begin
+		top_offsetdac_current_channel <= top_offsetdac_current_channel_offsetdac_f_next_value;
 	end
-	if (offsetdac_mux_S_offsetdac_t_next_value_ce) begin
-		mux_S <= offsetdac_mux_S_offsetdac_t_next_value;
+	if (top_offsetdac_mux_S_offsetdac_t_next_value_ce) begin
+		mux_S <= top_offsetdac_mux_S_offsetdac_t_next_value;
+	end
+	if ((top_lvdsreceiver0_d_valid & top_lvdsreceiver0_d_ready)) begin
+		if ((top_lvdsreceiver0_last_counter == 14'd16383)) begin
+			top_lvdsreceiver0_last_counter <= 1'd0;
+		end else begin
+			top_lvdsreceiver0_last_counter <= (top_lvdsreceiver0_last_counter + 1'd1);
+		end
+	end
+	if ((top_lvdsreceiver1_d_valid & top_lvdsreceiver1_d_ready)) begin
+		if ((top_lvdsreceiver1_last_counter == 14'd16383)) begin
+			top_lvdsreceiver1_last_counter <= 1'd0;
+		end else begin
+			top_lvdsreceiver1_last_counter <= (top_lvdsreceiver1_last_counter + 1'd1);
+		end
 	end
 	axi_lite_aw_ready <= 1'd0;
 	axi_lite_w_ready <= 1'd0;
 	if ((axi_lite_aw_valid & axi_lite_w_valid)) begin
-		if ((((~axi_lite_aw_ready) & (~busy)) & (~axi_lite_ar_valid))) begin
+		if ((((~axi_lite_aw_ready) & (~top_busy)) & (~axi_lite_ar_valid))) begin
 			axi_lite_aw_ready <= 1'd1;
 			axi_lite_w_ready <= 1'd1;
 		end
 	end
 	axi_lite_b_valid <= 1'd0;
-	if (write_transaction) begin
+	if (top_write_transaction) begin
 		if ((axi_lite_b_ready & (~axi_lite_b_valid))) begin
 			axi_lite_b_valid <= 1'd1;
 			axi_lite_b_resp <= 1'd0;
 		end
 	end
 	axi_lite_ar_ready <= 1'd0;
-	if (((axi_lite_ar_valid & (~axi_lite_ar_ready)) & (~busy))) begin
+	if (((axi_lite_ar_valid & (~axi_lite_ar_ready)) & (~top_busy))) begin
 		axi_lite_ar_ready <= 1'd1;
 	end
 	axilite2csr_state <= axilite2csr_next_state;
-	if (wdata_axilite2csr_next_value_ce) begin
-		wdata <= wdata_axilite2csr_next_value;
+	if (top_wdata_axilite2csr_next_value_ce) begin
+		top_wdata <= top_wdata_axilite2csr_next_value;
 	end
-	interface0_bank_bus_dat_r <= 1'd0;
-	if (csrbank0_sel) begin
-		case (interface0_bank_bus_adr[0])
+	top_interface0_bank_bus_dat_r <= 1'd0;
+	if (top_csrbank0_sel) begin
+		case (top_interface0_bank_bus_adr[0])
 			1'd0: begin
-				interface0_bank_bus_dat_r <= csrbank0_status_w;
+				top_interface0_bank_bus_dat_r <= top_csrbank0_status_w;
 			end
 			1'd1: begin
-				interface0_bank_bus_dat_r <= csrbank0_control0_w;
+				top_interface0_bank_bus_dat_r <= top_csrbank0_control0_w;
 			end
 		endcase
 	end
-	if (csrbank0_control0_re) begin
-		lvds_adc0_control_storage_full[31:0] <= csrbank0_control0_r;
+	if (top_csrbank0_control0_re) begin
+		top_lvdsreceiver0_control_storage_full[31:0] <= top_csrbank0_control0_r;
 	end
-	lvds_adc0_control_re <= csrbank0_control0_re;
-	interface1_bank_bus_dat_r <= 1'd0;
-	if (csrbank1_sel) begin
-		case (interface1_bank_bus_adr[3:0])
+	top_lvdsreceiver0_control_re <= top_csrbank0_control0_re;
+	top_interface1_bank_bus_dat_r <= 1'd0;
+	if (top_csrbank1_sel) begin
+		case (top_interface1_bank_bus_adr[0])
 			1'd0: begin
-				interface1_bank_bus_dat_r <= csrbank1_status_w;
+				top_interface1_bank_bus_dat_r <= top_csrbank1_status_w;
 			end
 			1'd1: begin
-				interface1_bank_bus_dat_r <= csrbank1_control0_w;
+				top_interface1_bank_bus_dat_r <= top_csrbank1_control0_w;
+			end
+		endcase
+	end
+	if (top_csrbank1_control0_re) begin
+		top_lvdsreceiver1_control_storage_full[31:0] <= top_csrbank1_control0_r;
+	end
+	top_lvdsreceiver1_control_re <= top_csrbank1_control0_re;
+	top_interface2_bank_bus_dat_r <= 1'd0;
+	if (top_csrbank2_sel) begin
+		case (top_interface2_bank_bus_adr[3:0])
+			1'd0: begin
+				top_interface2_bank_bus_dat_r <= top_csrbank2_status_w;
+			end
+			1'd1: begin
+				top_interface2_bank_bus_dat_r <= top_csrbank2_control0_w;
 			end
 			2'd2: begin
-				interface1_bank_bus_dat_r <= csrbank1_clkdiv0_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_clkdiv0_w;
 			end
 			2'd3: begin
-				interface1_bank_bus_dat_r <= csrbank1_enable0_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_enable0_w;
 			end
 			3'd4: begin
-				interface1_bank_bus_dat_r <= csrbank1_v00_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v00_w;
 			end
 			3'd5: begin
-				interface1_bank_bus_dat_r <= csrbank1_v10_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v10_w;
 			end
 			3'd6: begin
-				interface1_bank_bus_dat_r <= csrbank1_v20_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v20_w;
 			end
 			3'd7: begin
-				interface1_bank_bus_dat_r <= csrbank1_v30_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v30_w;
 			end
 			4'd8: begin
-				interface1_bank_bus_dat_r <= csrbank1_v40_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v40_w;
 			end
 			4'd9: begin
-				interface1_bank_bus_dat_r <= csrbank1_v50_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v50_w;
 			end
 			4'd10: begin
-				interface1_bank_bus_dat_r <= csrbank1_v60_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v60_w;
 			end
 			4'd11: begin
-				interface1_bank_bus_dat_r <= csrbank1_v70_w;
+				top_interface2_bank_bus_dat_r <= top_csrbank2_v70_w;
 			end
 		endcase
 	end
-	if (csrbank1_control0_re) begin
-		offsetdac_control_storage_full[31:0] <= csrbank1_control0_r;
+	if (top_csrbank2_control0_re) begin
+		top_offsetdac_control_storage_full[31:0] <= top_csrbank2_control0_r;
 	end
-	offsetdac_control_re <= csrbank1_control0_re;
-	if (csrbank1_clkdiv0_re) begin
-		offsetdac_clkdiv_storage_full[31:0] <= csrbank1_clkdiv0_r;
+	top_offsetdac_control_re <= top_csrbank2_control0_re;
+	if (top_csrbank2_clkdiv0_re) begin
+		top_offsetdac_clkdiv_storage_full[31:0] <= top_csrbank2_clkdiv0_r;
 	end
-	offsetdac_clkdiv_re <= csrbank1_clkdiv0_re;
-	if (csrbank1_enable0_re) begin
-		offsetdac_enable_storage_full[31:0] <= csrbank1_enable0_r;
+	top_offsetdac_clkdiv_re <= top_csrbank2_clkdiv0_re;
+	if (top_csrbank2_enable0_re) begin
+		top_offsetdac_enable_storage_full[31:0] <= top_csrbank2_enable0_r;
 	end
-	offsetdac_enable_re <= csrbank1_enable0_re;
-	if (csrbank1_v00_re) begin
-		offsetdac_v0_storage_full[31:0] <= csrbank1_v00_r;
+	top_offsetdac_enable_re <= top_csrbank2_enable0_re;
+	if (top_csrbank2_v00_re) begin
+		top_offsetdac_v0_storage_full[31:0] <= top_csrbank2_v00_r;
 	end
-	offsetdac_v0_re <= csrbank1_v00_re;
-	if (csrbank1_v10_re) begin
-		offsetdac_v1_storage_full[31:0] <= csrbank1_v10_r;
+	top_offsetdac_v0_re <= top_csrbank2_v00_re;
+	if (top_csrbank2_v10_re) begin
+		top_offsetdac_v1_storage_full[31:0] <= top_csrbank2_v10_r;
 	end
-	offsetdac_v1_re <= csrbank1_v10_re;
-	if (csrbank1_v20_re) begin
-		offsetdac_v2_storage_full[31:0] <= csrbank1_v20_r;
+	top_offsetdac_v1_re <= top_csrbank2_v10_re;
+	if (top_csrbank2_v20_re) begin
+		top_offsetdac_v2_storage_full[31:0] <= top_csrbank2_v20_r;
 	end
-	offsetdac_v2_re <= csrbank1_v20_re;
-	if (csrbank1_v30_re) begin
-		offsetdac_v3_storage_full[31:0] <= csrbank1_v30_r;
+	top_offsetdac_v2_re <= top_csrbank2_v20_re;
+	if (top_csrbank2_v30_re) begin
+		top_offsetdac_v3_storage_full[31:0] <= top_csrbank2_v30_r;
 	end
-	offsetdac_v3_re <= csrbank1_v30_re;
-	if (csrbank1_v40_re) begin
-		offsetdac_v4_storage_full[31:0] <= csrbank1_v40_r;
+	top_offsetdac_v3_re <= top_csrbank2_v30_re;
+	if (top_csrbank2_v40_re) begin
+		top_offsetdac_v4_storage_full[31:0] <= top_csrbank2_v40_r;
 	end
-	offsetdac_v4_re <= csrbank1_v40_re;
-	if (csrbank1_v50_re) begin
-		offsetdac_v5_storage_full[31:0] <= csrbank1_v50_r;
+	top_offsetdac_v4_re <= top_csrbank2_v40_re;
+	if (top_csrbank2_v50_re) begin
+		top_offsetdac_v5_storage_full[31:0] <= top_csrbank2_v50_r;
 	end
-	offsetdac_v5_re <= csrbank1_v50_re;
-	if (csrbank1_v60_re) begin
-		offsetdac_v6_storage_full[31:0] <= csrbank1_v60_r;
+	top_offsetdac_v5_re <= top_csrbank2_v50_re;
+	if (top_csrbank2_v60_re) begin
+		top_offsetdac_v6_storage_full[31:0] <= top_csrbank2_v60_r;
 	end
-	offsetdac_v6_re <= csrbank1_v60_re;
-	if (csrbank1_v70_re) begin
-		offsetdac_v7_storage_full[31:0] <= csrbank1_v70_r;
+	top_offsetdac_v6_re <= top_csrbank2_v60_re;
+	if (top_csrbank2_v70_re) begin
+		top_offsetdac_v7_storage_full[31:0] <= top_csrbank2_v70_r;
 	end
-	offsetdac_v7_re <= csrbank1_v70_re;
+	top_offsetdac_v7_re <= top_csrbank2_v70_re;
 	if (sys_rst) begin
 		spi_SCLK <= 1'd0;
 		spi_DIN <= 1'd0;
 		spi_nSYNC <= 1'd0;
 		mux_nE <= 1'd0;
 		mux_S <= 3'd0;
-		offsetdac_control_storage_full <= 32'd0;
-		offsetdac_control_re <= 1'd0;
-		offsetdac_clkdiv_storage_full <= 32'd326;
-		offsetdac_clkdiv_re <= 1'd0;
-		offsetdac_enable_storage_full <= 32'd1;
-		offsetdac_enable_re <= 1'd0;
-		offsetdac_v0_storage_full <= 32'd32768;
-		offsetdac_v0_re <= 1'd0;
-		offsetdac_v1_storage_full <= 32'd32768;
-		offsetdac_v1_re <= 1'd0;
-		offsetdac_v2_storage_full <= 32'd32768;
-		offsetdac_v2_re <= 1'd0;
-		offsetdac_v3_storage_full <= 32'd32768;
-		offsetdac_v3_re <= 1'd0;
-		offsetdac_v4_storage_full <= 32'd32768;
-		offsetdac_v4_re <= 1'd0;
-		offsetdac_v5_storage_full <= 32'd32768;
-		offsetdac_v5_re <= 1'd0;
-		offsetdac_v6_storage_full <= 32'd32768;
-		offsetdac_v6_re <= 1'd0;
-		offsetdac_v7_storage_full <= 32'd32768;
-		offsetdac_v7_re <= 1'd0;
-		offsetdac_clkdiv <= 16'd0;
-		offsetdac_clk <= 1'd0;
-		offsetdac_clk_falling <= 1'd0;
-		offsetdac_current_bit <= 5'd0;
-		offsetdac_current_channel <= 3'd0;
-		lvds_adc0_control_storage_full <= 32'd0;
-		lvds_adc0_control_re <= 1'd0;
+		top_offsetdac_control_storage_full <= 32'd0;
+		top_offsetdac_control_re <= 1'd0;
+		top_offsetdac_clkdiv_storage_full <= 32'd326;
+		top_offsetdac_clkdiv_re <= 1'd0;
+		top_offsetdac_enable_storage_full <= 32'd1;
+		top_offsetdac_enable_re <= 1'd0;
+		top_offsetdac_v0_storage_full <= 32'd32768;
+		top_offsetdac_v0_re <= 1'd0;
+		top_offsetdac_v1_storage_full <= 32'd32768;
+		top_offsetdac_v1_re <= 1'd0;
+		top_offsetdac_v2_storage_full <= 32'd32768;
+		top_offsetdac_v2_re <= 1'd0;
+		top_offsetdac_v3_storage_full <= 32'd32768;
+		top_offsetdac_v3_re <= 1'd0;
+		top_offsetdac_v4_storage_full <= 32'd32768;
+		top_offsetdac_v4_re <= 1'd0;
+		top_offsetdac_v5_storage_full <= 32'd32768;
+		top_offsetdac_v5_re <= 1'd0;
+		top_offsetdac_v6_storage_full <= 32'd32768;
+		top_offsetdac_v6_re <= 1'd0;
+		top_offsetdac_v7_storage_full <= 32'd32768;
+		top_offsetdac_v7_re <= 1'd0;
+		top_offsetdac_clkdiv <= 16'd0;
+		top_offsetdac_clk <= 1'd0;
+		top_offsetdac_clk_falling <= 1'd0;
+		top_offsetdac_current_bit <= 5'd0;
+		top_offsetdac_current_channel <= 3'd0;
+		top_lvdsreceiver0_control_storage_full <= 32'd0;
+		top_lvdsreceiver0_control_re <= 1'd0;
+		top_lvdsreceiver0_last_counter <= 14'd0;
+		top_lvdsreceiver1_control_storage_full <= 32'd0;
+		top_lvdsreceiver1_control_re <= 1'd0;
+		top_lvdsreceiver1_last_counter <= 14'd0;
 		axi_lite_aw_ready <= 1'd0;
 		axi_lite_w_ready <= 1'd0;
 		axi_lite_b_resp <= 2'd0;
 		axi_lite_b_valid <= 1'd0;
 		axi_lite_ar_ready <= 1'd0;
-		wdata <= 32'd0;
-		interface0_bank_bus_dat_r <= 32'd0;
-		interface1_bank_bus_dat_r <= 32'd0;
+		top_wdata <= 32'd0;
+		top_interface0_bank_bus_dat_r <= 32'd0;
+		top_interface1_bank_bus_dat_r <= 32'd0;
+		top_interface2_bank_bus_dat_r <= 32'd0;
 		offsetdac_state <= 1'd0;
 		axilite2csr_state <= 2'd0;
 	end
 end
 
 IBUFDS IBUFDS(
-	.I(lvds_pads_adc0_lclk_p),
-	.IB(lvds_pads_adc0_lclk_n),
-	.O(lvds_adc0_lclk_i)
+	.I(top_record0_lvds_pads_adc_lclk_p),
+	.IB(top_record0_lvds_pads_adc_lclk_n),
+	.O(top_lvdsreceiver0_lclk_i)
 );
 
 BUFIO BUFIO(
-	.I(lvds_adc0_lclk_i),
-	.O(lvds_adc0_lclk_i_bufio)
+	.I(top_lvdsreceiver0_lclk_i),
+	.O(top_lvdsreceiver0_lclk_i_bufio)
 );
 
 BUFR #(
 	.BUFR_DIVIDE("4")
 ) BUFR (
-	.I(lvds_adc0_lclk_i),
-	.O(lclkdiv_clk)
+	.I(top_lvdsreceiver0_lclk_i),
+	.O(adcif0_lclkdiv_clk)
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT(
-	.I(lvds_pads_adc0_d_p[0]),
-	.IB(lvds_pads_adc0_d_n[0]),
-	.O(lvds_adc0_serdes_i_nodelay0)
+	.I(top_record0_lvds_pads_adc_d_p[0]),
+	.IB(top_record0_lvds_pads_adc_d_n[0]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay0)
 );
 
 IDELAYE2 #(
@@ -907,13 +1191,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay0),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay0),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed0)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed0)
 );
 
 ISERDESE2 #(
@@ -924,27 +1208,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed0),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q0[7]),
-	.Q2(lvds_adc0_serdes_q0[6]),
-	.Q3(lvds_adc0_serdes_q0[5]),
-	.Q4(lvds_adc0_serdes_q0[4]),
-	.Q5(lvds_adc0_serdes_q0[3]),
-	.Q6(lvds_adc0_serdes_q0[2]),
-	.Q7(lvds_adc0_serdes_q0[1]),
-	.Q8(lvds_adc0_serdes_q0[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed0),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q0[7]),
+	.Q2(top_lvdsreceiver0_serdes_q0[6]),
+	.Q3(top_lvdsreceiver0_serdes_q0[5]),
+	.Q4(top_lvdsreceiver0_serdes_q0[4]),
+	.Q5(top_lvdsreceiver0_serdes_q0[3]),
+	.Q6(top_lvdsreceiver0_serdes_q0[2]),
+	.Q7(top_lvdsreceiver0_serdes_q0[1]),
+	.Q8(top_lvdsreceiver0_serdes_q0[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_1(
-	.I(lvds_pads_adc0_d_p[1]),
-	.IB(lvds_pads_adc0_d_n[1]),
-	.O(lvds_adc0_serdes_i_nodelay1)
+	.I(top_record0_lvds_pads_adc_d_p[1]),
+	.IB(top_record0_lvds_pads_adc_d_n[1]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay1)
 );
 
 IDELAYE2 #(
@@ -957,13 +1241,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_1 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay1),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay1),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed1)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed1)
 );
 
 ISERDESE2 #(
@@ -974,27 +1258,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_1 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed1),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q1[7]),
-	.Q2(lvds_adc0_serdes_q1[6]),
-	.Q3(lvds_adc0_serdes_q1[5]),
-	.Q4(lvds_adc0_serdes_q1[4]),
-	.Q5(lvds_adc0_serdes_q1[3]),
-	.Q6(lvds_adc0_serdes_q1[2]),
-	.Q7(lvds_adc0_serdes_q1[1]),
-	.Q8(lvds_adc0_serdes_q1[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed1),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q1[7]),
+	.Q2(top_lvdsreceiver0_serdes_q1[6]),
+	.Q3(top_lvdsreceiver0_serdes_q1[5]),
+	.Q4(top_lvdsreceiver0_serdes_q1[4]),
+	.Q5(top_lvdsreceiver0_serdes_q1[3]),
+	.Q6(top_lvdsreceiver0_serdes_q1[2]),
+	.Q7(top_lvdsreceiver0_serdes_q1[1]),
+	.Q8(top_lvdsreceiver0_serdes_q1[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_2(
-	.I(lvds_pads_adc0_d_p[2]),
-	.IB(lvds_pads_adc0_d_n[2]),
-	.O(lvds_adc0_serdes_i_nodelay2)
+	.I(top_record0_lvds_pads_adc_d_p[2]),
+	.IB(top_record0_lvds_pads_adc_d_n[2]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay2)
 );
 
 IDELAYE2 #(
@@ -1007,13 +1291,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_2 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay2),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay2),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed2)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed2)
 );
 
 ISERDESE2 #(
@@ -1024,27 +1308,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_2 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed2),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q2[7]),
-	.Q2(lvds_adc0_serdes_q2[6]),
-	.Q3(lvds_adc0_serdes_q2[5]),
-	.Q4(lvds_adc0_serdes_q2[4]),
-	.Q5(lvds_adc0_serdes_q2[3]),
-	.Q6(lvds_adc0_serdes_q2[2]),
-	.Q7(lvds_adc0_serdes_q2[1]),
-	.Q8(lvds_adc0_serdes_q2[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed2),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q2[7]),
+	.Q2(top_lvdsreceiver0_serdes_q2[6]),
+	.Q3(top_lvdsreceiver0_serdes_q2[5]),
+	.Q4(top_lvdsreceiver0_serdes_q2[4]),
+	.Q5(top_lvdsreceiver0_serdes_q2[3]),
+	.Q6(top_lvdsreceiver0_serdes_q2[2]),
+	.Q7(top_lvdsreceiver0_serdes_q2[1]),
+	.Q8(top_lvdsreceiver0_serdes_q2[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_3(
-	.I(lvds_pads_adc0_d_p[3]),
-	.IB(lvds_pads_adc0_d_n[3]),
-	.O(lvds_adc0_serdes_i_nodelay3)
+	.I(top_record0_lvds_pads_adc_d_p[3]),
+	.IB(top_record0_lvds_pads_adc_d_n[3]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay3)
 );
 
 IDELAYE2 #(
@@ -1057,13 +1341,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_3 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay3),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay3),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed3)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed3)
 );
 
 ISERDESE2 #(
@@ -1074,27 +1358,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_3 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed3),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q3[7]),
-	.Q2(lvds_adc0_serdes_q3[6]),
-	.Q3(lvds_adc0_serdes_q3[5]),
-	.Q4(lvds_adc0_serdes_q3[4]),
-	.Q5(lvds_adc0_serdes_q3[3]),
-	.Q6(lvds_adc0_serdes_q3[2]),
-	.Q7(lvds_adc0_serdes_q3[1]),
-	.Q8(lvds_adc0_serdes_q3[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed3),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q3[7]),
+	.Q2(top_lvdsreceiver0_serdes_q3[6]),
+	.Q3(top_lvdsreceiver0_serdes_q3[5]),
+	.Q4(top_lvdsreceiver0_serdes_q3[4]),
+	.Q5(top_lvdsreceiver0_serdes_q3[3]),
+	.Q6(top_lvdsreceiver0_serdes_q3[2]),
+	.Q7(top_lvdsreceiver0_serdes_q3[1]),
+	.Q8(top_lvdsreceiver0_serdes_q3[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_4(
-	.I(lvds_pads_adc0_d_p[4]),
-	.IB(lvds_pads_adc0_d_n[4]),
-	.O(lvds_adc0_serdes_i_nodelay4)
+	.I(top_record0_lvds_pads_adc_d_p[4]),
+	.IB(top_record0_lvds_pads_adc_d_n[4]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay4)
 );
 
 IDELAYE2 #(
@@ -1107,13 +1391,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_4 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay4),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay4),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed4)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed4)
 );
 
 ISERDESE2 #(
@@ -1124,27 +1408,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_4 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed4),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q4[7]),
-	.Q2(lvds_adc0_serdes_q4[6]),
-	.Q3(lvds_adc0_serdes_q4[5]),
-	.Q4(lvds_adc0_serdes_q4[4]),
-	.Q5(lvds_adc0_serdes_q4[3]),
-	.Q6(lvds_adc0_serdes_q4[2]),
-	.Q7(lvds_adc0_serdes_q4[1]),
-	.Q8(lvds_adc0_serdes_q4[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed4),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q4[7]),
+	.Q2(top_lvdsreceiver0_serdes_q4[6]),
+	.Q3(top_lvdsreceiver0_serdes_q4[5]),
+	.Q4(top_lvdsreceiver0_serdes_q4[4]),
+	.Q5(top_lvdsreceiver0_serdes_q4[3]),
+	.Q6(top_lvdsreceiver0_serdes_q4[2]),
+	.Q7(top_lvdsreceiver0_serdes_q4[1]),
+	.Q8(top_lvdsreceiver0_serdes_q4[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_5(
-	.I(lvds_pads_adc0_d_p[5]),
-	.IB(lvds_pads_adc0_d_n[5]),
-	.O(lvds_adc0_serdes_i_nodelay5)
+	.I(top_record0_lvds_pads_adc_d_p[5]),
+	.IB(top_record0_lvds_pads_adc_d_n[5]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay5)
 );
 
 IDELAYE2 #(
@@ -1157,13 +1441,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_5 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay5),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay5),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed5)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed5)
 );
 
 ISERDESE2 #(
@@ -1174,27 +1458,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_5 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed5),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q5[7]),
-	.Q2(lvds_adc0_serdes_q5[6]),
-	.Q3(lvds_adc0_serdes_q5[5]),
-	.Q4(lvds_adc0_serdes_q5[4]),
-	.Q5(lvds_adc0_serdes_q5[3]),
-	.Q6(lvds_adc0_serdes_q5[2]),
-	.Q7(lvds_adc0_serdes_q5[1]),
-	.Q8(lvds_adc0_serdes_q5[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed5),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q5[7]),
+	.Q2(top_lvdsreceiver0_serdes_q5[6]),
+	.Q3(top_lvdsreceiver0_serdes_q5[5]),
+	.Q4(top_lvdsreceiver0_serdes_q5[4]),
+	.Q5(top_lvdsreceiver0_serdes_q5[3]),
+	.Q6(top_lvdsreceiver0_serdes_q5[2]),
+	.Q7(top_lvdsreceiver0_serdes_q5[1]),
+	.Q8(top_lvdsreceiver0_serdes_q5[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_6(
-	.I(lvds_pads_adc0_d_p[6]),
-	.IB(lvds_pads_adc0_d_n[6]),
-	.O(lvds_adc0_serdes_i_nodelay6)
+	.I(top_record0_lvds_pads_adc_d_p[6]),
+	.IB(top_record0_lvds_pads_adc_d_n[6]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay6)
 );
 
 IDELAYE2 #(
@@ -1207,13 +1491,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_6 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay6),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay6),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed6)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed6)
 );
 
 ISERDESE2 #(
@@ -1224,27 +1508,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_6 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed6),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q6[7]),
-	.Q2(lvds_adc0_serdes_q6[6]),
-	.Q3(lvds_adc0_serdes_q6[5]),
-	.Q4(lvds_adc0_serdes_q6[4]),
-	.Q5(lvds_adc0_serdes_q6[3]),
-	.Q6(lvds_adc0_serdes_q6[2]),
-	.Q7(lvds_adc0_serdes_q6[1]),
-	.Q8(lvds_adc0_serdes_q6[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed6),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q6[7]),
+	.Q2(top_lvdsreceiver0_serdes_q6[6]),
+	.Q3(top_lvdsreceiver0_serdes_q6[5]),
+	.Q4(top_lvdsreceiver0_serdes_q6[4]),
+	.Q5(top_lvdsreceiver0_serdes_q6[3]),
+	.Q6(top_lvdsreceiver0_serdes_q6[2]),
+	.Q7(top_lvdsreceiver0_serdes_q6[1]),
+	.Q8(top_lvdsreceiver0_serdes_q6[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_7(
-	.I(lvds_pads_adc0_d_p[7]),
-	.IB(lvds_pads_adc0_d_n[7]),
-	.O(lvds_adc0_serdes_i_nodelay7)
+	.I(top_record0_lvds_pads_adc_d_p[7]),
+	.IB(top_record0_lvds_pads_adc_d_n[7]),
+	.O(top_lvdsreceiver0_serdes_i_nodelay7)
 );
 
 IDELAYE2 #(
@@ -1257,13 +1541,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_7 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay7),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay7),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed7)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed7)
 );
 
 ISERDESE2 #(
@@ -1274,27 +1558,27 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_7 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed7),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q7[7]),
-	.Q2(lvds_adc0_serdes_q7[6]),
-	.Q3(lvds_adc0_serdes_q7[5]),
-	.Q4(lvds_adc0_serdes_q7[4]),
-	.Q5(lvds_adc0_serdes_q7[3]),
-	.Q6(lvds_adc0_serdes_q7[2]),
-	.Q7(lvds_adc0_serdes_q7[1]),
-	.Q8(lvds_adc0_serdes_q7[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed7),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q7[7]),
+	.Q2(top_lvdsreceiver0_serdes_q7[6]),
+	.Q3(top_lvdsreceiver0_serdes_q7[5]),
+	.Q4(top_lvdsreceiver0_serdes_q7[4]),
+	.Q5(top_lvdsreceiver0_serdes_q7[3]),
+	.Q6(top_lvdsreceiver0_serdes_q7[2]),
+	.Q7(top_lvdsreceiver0_serdes_q7[1]),
+	.Q8(top_lvdsreceiver0_serdes_q7[0])
 );
 
 IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_8(
-	.I(lvds_pads_adc0_fclk_p),
-	.IB(lvds_pads_adc0_fclk_n),
-	.O(lvds_adc0_serdes_i_nodelay8)
+	.I(top_record0_lvds_pads_adc_fclk_p),
+	.IB(top_record0_lvds_pads_adc_fclk_n),
+	.O(top_lvdsreceiver0_serdes_i_nodelay8)
 );
 
 IDELAYE2 #(
@@ -1307,13 +1591,13 @@ IDELAYE2 #(
 	.REFCLK_FREQUENCY(200.0),
 	.SIGNAL_PATTERN("DATA")
 ) IDELAYE2_8 (
-	.C(lclkdiv_clk),
-	.CE(lvds_adc0_rx_delay_inc),
-	.IDATAIN(lvds_adc0_serdes_i_nodelay8),
+	.C(adcif0_lclkdiv_clk),
+	.CE(top_lvdsreceiver0_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver0_serdes_i_nodelay8),
 	.INC(1'd1),
-	.LD(lvds_adc0_rx_delay_rst),
+	.LD(top_lvdsreceiver0_rx_delay_rst),
 	.LDPIPEEN(1'd0),
-	.DATAOUT(lvds_adc0_serdes_i_delayed8)
+	.DATAOUT(top_lvdsreceiver0_serdes_i_delayed8)
 );
 
 ISERDESE2 #(
@@ -1324,42 +1608,526 @@ ISERDESE2 #(
 	.NUM_CE(1'd1),
 	.SERDES_MODE("MASTER")
 ) ISERDESE2_8 (
-	.BITSLIP(lvds_adc0_bitslip_do),
+	.BITSLIP(top_lvdsreceiver0_bitslip_do),
 	.CE1(1'd1),
-	.CLK(lvds_adc0_lclk_i_bufio),
-	.CLKB((~lvds_adc0_lclk_i_bufio)),
-	.CLKDIV(lclkdiv_clk),
-	.DDLY(lvds_adc0_serdes_i_delayed8),
-	.RST(lclkdiv_rst),
-	.Q1(lvds_adc0_serdes_q8[7]),
-	.Q2(lvds_adc0_serdes_q8[6]),
-	.Q3(lvds_adc0_serdes_q8[5]),
-	.Q4(lvds_adc0_serdes_q8[4]),
-	.Q5(lvds_adc0_serdes_q8[3]),
-	.Q6(lvds_adc0_serdes_q8[2]),
-	.Q7(lvds_adc0_serdes_q8[1]),
-	.Q8(lvds_adc0_serdes_q8[0])
+	.CLK(top_lvdsreceiver0_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver0_lclk_i_bufio)),
+	.CLKDIV(adcif0_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver0_serdes_i_delayed8),
+	.RST(adcif0_lclkdiv_rst),
+	.Q1(top_lvdsreceiver0_serdes_q8[7]),
+	.Q2(top_lvdsreceiver0_serdes_q8[6]),
+	.Q3(top_lvdsreceiver0_serdes_q8[5]),
+	.Q4(top_lvdsreceiver0_serdes_q8[4]),
+	.Q5(top_lvdsreceiver0_serdes_q8[3]),
+	.Q6(top_lvdsreceiver0_serdes_q8[2]),
+	.Q7(top_lvdsreceiver0_serdes_q8[1]),
+	.Q8(top_lvdsreceiver0_serdes_q8[0])
 );
 
 reg [71:0] storage[0:63];
 reg [5:0] memadr;
 reg [5:0] memadr_1;
-always @(posedge lclkdiv_clk) begin
-	if (lvds_adc0_data_fifo_wrport_we)
-		storage[lvds_adc0_data_fifo_wrport_adr] <= lvds_adc0_data_fifo_wrport_dat_w;
-	memadr <= lvds_adc0_data_fifo_wrport_adr;
+always @(posedge adcif0_lclkdiv_clk) begin
+	if (top_lvdsreceiver0_data_fifo_wrport_we)
+		storage[top_lvdsreceiver0_data_fifo_wrport_adr] <= top_lvdsreceiver0_data_fifo_wrport_dat_w;
+	memadr <= top_lvdsreceiver0_data_fifo_wrport_adr;
 end
 
-always @(posedge data_clk_1) begin
-	memadr_1 <= lvds_adc0_data_fifo_rdport_adr;
+always @(posedge adcif0_data_clk) begin
+	memadr_1 <= top_lvdsreceiver0_data_fifo_rdport_adr;
 end
 
-assign lvds_adc0_data_fifo_wrport_dat_r = storage[memadr];
-assign lvds_adc0_data_fifo_rdport_dat_r = storage[memadr_1];
+assign top_lvdsreceiver0_data_fifo_wrport_dat_r = storage[memadr];
+assign top_lvdsreceiver0_data_fifo_rdport_dat_r = storage[memadr_1];
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(sys_clk),
 	.RST(sys_rst)
 );
+
+IBUFDS IBUFDS_1(
+	.I(top_record1_lvds_pads_adc_lclk_p),
+	.IB(top_record1_lvds_pads_adc_lclk_n),
+	.O(top_lvdsreceiver1_lclk_i)
+);
+
+BUFIO BUFIO_1(
+	.I(top_lvdsreceiver1_lclk_i),
+	.O(top_lvdsreceiver1_lclk_i_bufio)
+);
+
+BUFR #(
+	.BUFR_DIVIDE("4")
+) BUFR_1 (
+	.I(top_lvdsreceiver1_lclk_i),
+	.O(adcif1_lclkdiv_clk)
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_9(
+	.I(top_record1_lvds_pads_adc_d_p[0]),
+	.IB(top_record1_lvds_pads_adc_d_n[0]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay0)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_9 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay0),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed0)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_9 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed0),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q0[7]),
+	.Q2(top_lvdsreceiver1_serdes_q0[6]),
+	.Q3(top_lvdsreceiver1_serdes_q0[5]),
+	.Q4(top_lvdsreceiver1_serdes_q0[4]),
+	.Q5(top_lvdsreceiver1_serdes_q0[3]),
+	.Q6(top_lvdsreceiver1_serdes_q0[2]),
+	.Q7(top_lvdsreceiver1_serdes_q0[1]),
+	.Q8(top_lvdsreceiver1_serdes_q0[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_10(
+	.I(top_record1_lvds_pads_adc_d_p[1]),
+	.IB(top_record1_lvds_pads_adc_d_n[1]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay1)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_10 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay1),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed1)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_10 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed1),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q1[7]),
+	.Q2(top_lvdsreceiver1_serdes_q1[6]),
+	.Q3(top_lvdsreceiver1_serdes_q1[5]),
+	.Q4(top_lvdsreceiver1_serdes_q1[4]),
+	.Q5(top_lvdsreceiver1_serdes_q1[3]),
+	.Q6(top_lvdsreceiver1_serdes_q1[2]),
+	.Q7(top_lvdsreceiver1_serdes_q1[1]),
+	.Q8(top_lvdsreceiver1_serdes_q1[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_11(
+	.I(top_record1_lvds_pads_adc_d_p[2]),
+	.IB(top_record1_lvds_pads_adc_d_n[2]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay2)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_11 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay2),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed2)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_11 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed2),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q2[7]),
+	.Q2(top_lvdsreceiver1_serdes_q2[6]),
+	.Q3(top_lvdsreceiver1_serdes_q2[5]),
+	.Q4(top_lvdsreceiver1_serdes_q2[4]),
+	.Q5(top_lvdsreceiver1_serdes_q2[3]),
+	.Q6(top_lvdsreceiver1_serdes_q2[2]),
+	.Q7(top_lvdsreceiver1_serdes_q2[1]),
+	.Q8(top_lvdsreceiver1_serdes_q2[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_12(
+	.I(top_record1_lvds_pads_adc_d_p[3]),
+	.IB(top_record1_lvds_pads_adc_d_n[3]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay3)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_12 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay3),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed3)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_12 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed3),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q3[7]),
+	.Q2(top_lvdsreceiver1_serdes_q3[6]),
+	.Q3(top_lvdsreceiver1_serdes_q3[5]),
+	.Q4(top_lvdsreceiver1_serdes_q3[4]),
+	.Q5(top_lvdsreceiver1_serdes_q3[3]),
+	.Q6(top_lvdsreceiver1_serdes_q3[2]),
+	.Q7(top_lvdsreceiver1_serdes_q3[1]),
+	.Q8(top_lvdsreceiver1_serdes_q3[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_13(
+	.I(top_record1_lvds_pads_adc_d_p[4]),
+	.IB(top_record1_lvds_pads_adc_d_n[4]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay4)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_13 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay4),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed4)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_13 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed4),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q4[7]),
+	.Q2(top_lvdsreceiver1_serdes_q4[6]),
+	.Q3(top_lvdsreceiver1_serdes_q4[5]),
+	.Q4(top_lvdsreceiver1_serdes_q4[4]),
+	.Q5(top_lvdsreceiver1_serdes_q4[3]),
+	.Q6(top_lvdsreceiver1_serdes_q4[2]),
+	.Q7(top_lvdsreceiver1_serdes_q4[1]),
+	.Q8(top_lvdsreceiver1_serdes_q4[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_14(
+	.I(top_record1_lvds_pads_adc_d_p[5]),
+	.IB(top_record1_lvds_pads_adc_d_n[5]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay5)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_14 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay5),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed5)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_14 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed5),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q5[7]),
+	.Q2(top_lvdsreceiver1_serdes_q5[6]),
+	.Q3(top_lvdsreceiver1_serdes_q5[5]),
+	.Q4(top_lvdsreceiver1_serdes_q5[4]),
+	.Q5(top_lvdsreceiver1_serdes_q5[3]),
+	.Q6(top_lvdsreceiver1_serdes_q5[2]),
+	.Q7(top_lvdsreceiver1_serdes_q5[1]),
+	.Q8(top_lvdsreceiver1_serdes_q5[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_15(
+	.I(top_record1_lvds_pads_adc_d_p[6]),
+	.IB(top_record1_lvds_pads_adc_d_n[6]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay6)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_15 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay6),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed6)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_15 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed6),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q6[7]),
+	.Q2(top_lvdsreceiver1_serdes_q6[6]),
+	.Q3(top_lvdsreceiver1_serdes_q6[5]),
+	.Q4(top_lvdsreceiver1_serdes_q6[4]),
+	.Q5(top_lvdsreceiver1_serdes_q6[3]),
+	.Q6(top_lvdsreceiver1_serdes_q6[2]),
+	.Q7(top_lvdsreceiver1_serdes_q6[1]),
+	.Q8(top_lvdsreceiver1_serdes_q6[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_16(
+	.I(top_record1_lvds_pads_adc_d_p[7]),
+	.IB(top_record1_lvds_pads_adc_d_n[7]),
+	.O(top_lvdsreceiver1_serdes_i_nodelay7)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_16 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay7),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed7)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_16 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed7),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q7[7]),
+	.Q2(top_lvdsreceiver1_serdes_q7[6]),
+	.Q3(top_lvdsreceiver1_serdes_q7[5]),
+	.Q4(top_lvdsreceiver1_serdes_q7[4]),
+	.Q5(top_lvdsreceiver1_serdes_q7[3]),
+	.Q6(top_lvdsreceiver1_serdes_q7[2]),
+	.Q7(top_lvdsreceiver1_serdes_q7[1]),
+	.Q8(top_lvdsreceiver1_serdes_q7[0])
+);
+
+IBUFDS_DIFF_OUT IBUFDS_DIFF_OUT_17(
+	.I(top_record1_lvds_pads_adc_fclk_p),
+	.IB(top_record1_lvds_pads_adc_fclk_n),
+	.O(top_lvdsreceiver1_serdes_i_nodelay8)
+);
+
+IDELAYE2 #(
+	.CINVCTRL_SEL("FALSE"),
+	.DELAY_SRC("IDATAIN"),
+	.HIGH_PERFORMANCE_MODE("TRUE"),
+	.IDELAY_TYPE("VARIABLE"),
+	.IDELAY_VALUE(1'd0),
+	.PIPE_SEL("FALSE"),
+	.REFCLK_FREQUENCY(200.0),
+	.SIGNAL_PATTERN("DATA")
+) IDELAYE2_17 (
+	.C(adcif1_lclkdiv_clk),
+	.CE(top_lvdsreceiver1_rx_delay_inc),
+	.IDATAIN(top_lvdsreceiver1_serdes_i_nodelay8),
+	.INC(1'd1),
+	.LD(top_lvdsreceiver1_rx_delay_rst),
+	.LDPIPEEN(1'd0),
+	.DATAOUT(top_lvdsreceiver1_serdes_i_delayed8)
+);
+
+ISERDESE2 #(
+	.DATA_RATE("DDR"),
+	.DATA_WIDTH(4'd8),
+	.INTERFACE_TYPE("NETWORKING"),
+	.IOBDELAY("IFD"),
+	.NUM_CE(1'd1),
+	.SERDES_MODE("MASTER")
+) ISERDESE2_17 (
+	.BITSLIP(top_lvdsreceiver1_bitslip_do),
+	.CE1(1'd1),
+	.CLK(top_lvdsreceiver1_lclk_i_bufio),
+	.CLKB((~top_lvdsreceiver1_lclk_i_bufio)),
+	.CLKDIV(adcif1_lclkdiv_clk),
+	.DDLY(top_lvdsreceiver1_serdes_i_delayed8),
+	.RST(adcif1_lclkdiv_rst),
+	.Q1(top_lvdsreceiver1_serdes_q8[7]),
+	.Q2(top_lvdsreceiver1_serdes_q8[6]),
+	.Q3(top_lvdsreceiver1_serdes_q8[5]),
+	.Q4(top_lvdsreceiver1_serdes_q8[4]),
+	.Q5(top_lvdsreceiver1_serdes_q8[3]),
+	.Q6(top_lvdsreceiver1_serdes_q8[2]),
+	.Q7(top_lvdsreceiver1_serdes_q8[1]),
+	.Q8(top_lvdsreceiver1_serdes_q8[0])
+);
+
+reg [71:0] storage_1[0:63];
+reg [5:0] memadr_2;
+reg [5:0] memadr_3;
+always @(posedge adcif1_lclkdiv_clk) begin
+	if (top_lvdsreceiver1_data_fifo_wrport_we)
+		storage_1[top_lvdsreceiver1_data_fifo_wrport_adr] <= top_lvdsreceiver1_data_fifo_wrport_dat_w;
+	memadr_2 <= top_lvdsreceiver1_data_fifo_wrport_adr;
+end
+
+always @(posedge adcif1_data_clk) begin
+	memadr_3 <= top_lvdsreceiver1_data_fifo_rdport_adr;
+end
+
+assign top_lvdsreceiver1_data_fifo_wrport_dat_r = storage_1[memadr_2];
+assign top_lvdsreceiver1_data_fifo_rdport_dat_r = storage_1[memadr_3];
 
 endmodule

--- a/projects/sds1104xe/sds1104xe_top.sv
+++ b/projects/sds1104xe/sds1104xe_top.sv
@@ -11,6 +11,7 @@
 
 module sds1104xe
    (ADC_0,
+   ADC_1,
  CAPTURE_SPI_CSN,
  CAPTURE_SPI_MOSI,
  CAPTURE_SPI_SCLK,
@@ -74,6 +75,7 @@ module sds1104xe
  VID_VSYNC
  );
 input [19:0]ADC_0;
+input [19:0]ADC_1;
 output [7:0]CAPTURE_SPI_CSN;
 output CAPTURE_SPI_MOSI;
 output CAPTURE_SPI_SCLK;
@@ -137,6 +139,7 @@ output VID_PIXEL_CLK;
 output VID_VSYNC;
 
 wire [19:0]ADC_0;
+wire [19:0]ADC_1;
 wire [7:0]CAPTURE_SPI_CSN;
 wire CAPTURE_SPI_MOSI;
 wire CAPTURE_SPI_SCLK;
@@ -217,6 +220,7 @@ IOBUF ETHERNET_MDIO_mdio_iobuf
      .T(ETHERNET_MDIO_mdio_t));
 system system_i
     (.ADC_0(ADC_0),
+     .ADC_1(ADC_1),
      .CAPTURE_SPI_CSN(CAPTURE_SPI_CSN),
      .CAPTURE_SPI_MOSI(CAPTURE_SPI_MOSI),
      .CAPTURE_SPI_SCLK(CAPTURE_SPI_SCLK),

--- a/projects/sds1104xe/sds1104xe_top.tcl
+++ b/projects/sds1104xe/sds1104xe_top.tcl
@@ -132,6 +132,7 @@ xilinx.com:ip:mig_7series:4.1\
 xilinx.com:ip:proc_sys_reset:5.0\
 xilinx.com:ip:processing_system7:5.5\
 user.org:user:spi_decoder_3_to_n:1.0\
+xilinx.com:ip:system_ila:1.1\
 xilinx.com:ip:xlconstant:1.1\
 xilinx.com:ip:axi_vdma:6.3\
 xilinx.com:ip:clk_wiz:6.0\
@@ -318,7 +319,7 @@ proc write_mig_file_system_mig_7series_0_0 { str_mig_prj_filepath } {
    puts $mig_prj_file {            <C0_S_AXI_ADDR_WIDTH>28</C0_S_AXI_ADDR_WIDTH>}
    puts $mig_prj_file {            <C0_S_AXI_DATA_WIDTH>128</C0_S_AXI_DATA_WIDTH>}
    puts $mig_prj_file {            <C0_S_AXI_ID_WIDTH>2</C0_S_AXI_ID_WIDTH>}
-   puts $mig_prj_file {            <C0_S_AXI_SUPPORTS_NARROW_BURST>0</C0_S_AXI_SUPPORTS_NARROW_BURST>}
+   puts $mig_prj_file {            <C0_S_AXI_SUPPORTS_NARROW_BURST>1</C0_S_AXI_SUPPORTS_NARROW_BURST>}
    puts $mig_prj_file {        </AXIParameters>}
    puts $mig_prj_file {    </Controller>}
    puts $mig_prj_file {</Project>}
@@ -556,6 +557,7 @@ proc create_root_design { parentCell } {
 
   # Create ports
   set ADC_0 [ create_bd_port -dir I -from 19 -to 0 ADC_0 ]
+  set ADC_1 [ create_bd_port -dir I -from 19 -to 0 ADC_1 ]
   set CAPTURE_SPI_CSN [ create_bd_port -dir O -from 7 -to 0 CAPTURE_SPI_CSN ]
   set CAPTURE_SPI_MOSI [ create_bd_port -dir O CAPTURE_SPI_MOSI ]
   set CAPTURE_SPI_SCLK [ create_bd_port -dir O CAPTURE_SPI_SCLK ]
@@ -589,14 +591,16 @@ proc create_root_design { parentCell } {
   set_property -dict [ list \
    CONFIG.c_include_mm2s {0} \
    CONFIG.c_include_sg {0} \
+   CONFIG.c_s2mm_burst_size {256} \
    CONFIG.c_sg_include_stscntrl_strm {0} \
+   CONFIG.c_sg_length_width {23} \
  ] $adc1_dma
 
   # Create instance: axi_acq_interconnect, and set properties
   set axi_acq_interconnect [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_acq_interconnect ]
   set_property -dict [ list \
    CONFIG.NUM_MI {1} \
-   CONFIG.NUM_SI {3} \
+   CONFIG.NUM_SI {4} \
    CONFIG.S00_HAS_DATA_FIFO {2} \
    CONFIG.S01_HAS_DATA_FIFO {2} \
    CONFIG.S02_HAS_DATA_FIFO {0} \
@@ -613,7 +617,7 @@ proc create_root_design { parentCell } {
   set axi_interconnect_peripherals [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_interconnect:2.1 axi_interconnect_peripherals ]
   set_property -dict [ list \
    CONFIG.M03_HAS_DATA_FIFO {2} \
-   CONFIG.NUM_MI {5} \
+   CONFIG.NUM_MI {6} \
    CONFIG.NUM_SI {1} \
    CONFIG.S01_HAS_DATA_FIFO {2} \
  ] $axi_interconnect_peripherals
@@ -651,69 +655,6 @@ proc create_root_design { parentCell } {
    CONFIG.C_MONITOR_TYPE {AXI} \
    CONFIG.C_NUM_OF_PROBES {19} \
  ] $ila_1
-
-  # Create instance: ila_2, and set properties
-  set ila_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ila:6.2 ila_2 ]
-  set_property -dict [ list \
-   CONFIG.ALL_PROBE_SAME_MU_CNT {2} \
-   CONFIG.C_ENABLE_ILA_AXI_MON {false} \
-   CONFIG.C_EN_STRG_QUAL {1} \
-   CONFIG.C_MONITOR_TYPE {Native} \
-   CONFIG.C_NUM_OF_PROBES {1} \
-   CONFIG.C_PROBE0_MU_CNT {2} \
-   CONFIG.C_PROBE0_WIDTH {64} \
-   CONFIG.C_PROBE10_MU_CNT {2} \
-   CONFIG.C_PROBE11_MU_CNT {2} \
-   CONFIG.C_PROBE12_MU_CNT {2} \
-   CONFIG.C_PROBE13_MU_CNT {2} \
-   CONFIG.C_PROBE14_MU_CNT {2} \
-   CONFIG.C_PROBE15_MU_CNT {2} \
-   CONFIG.C_PROBE16_MU_CNT {2} \
-   CONFIG.C_PROBE17_MU_CNT {2} \
-   CONFIG.C_PROBE18_MU_CNT {2} \
-   CONFIG.C_PROBE19_MU_CNT {2} \
-   CONFIG.C_PROBE1_MU_CNT {2} \
-   CONFIG.C_PROBE1_WIDTH {1} \
-   CONFIG.C_PROBE20_MU_CNT {2} \
-   CONFIG.C_PROBE21_MU_CNT {2} \
-   CONFIG.C_PROBE22_MU_CNT {2} \
-   CONFIG.C_PROBE23_MU_CNT {2} \
-   CONFIG.C_PROBE24_MU_CNT {2} \
-   CONFIG.C_PROBE25_MU_CNT {2} \
-   CONFIG.C_PROBE26_MU_CNT {2} \
-   CONFIG.C_PROBE27_MU_CNT {2} \
-   CONFIG.C_PROBE28_MU_CNT {2} \
-   CONFIG.C_PROBE29_MU_CNT {2} \
-   CONFIG.C_PROBE2_MU_CNT {2} \
-   CONFIG.C_PROBE2_WIDTH {1} \
-   CONFIG.C_PROBE30_MU_CNT {2} \
-   CONFIG.C_PROBE31_MU_CNT {2} \
-   CONFIG.C_PROBE32_MU_CNT {2} \
-   CONFIG.C_PROBE33_MU_CNT {2} \
-   CONFIG.C_PROBE34_MU_CNT {2} \
-   CONFIG.C_PROBE35_MU_CNT {2} \
-   CONFIG.C_PROBE36_MU_CNT {2} \
-   CONFIG.C_PROBE37_MU_CNT {2} \
-   CONFIG.C_PROBE38_MU_CNT {2} \
-   CONFIG.C_PROBE39_MU_CNT {2} \
-   CONFIG.C_PROBE3_MU_CNT {2} \
-   CONFIG.C_PROBE3_WIDTH {1} \
-   CONFIG.C_PROBE40_MU_CNT {2} \
-   CONFIG.C_PROBE41_MU_CNT {2} \
-   CONFIG.C_PROBE42_MU_CNT {2} \
-   CONFIG.C_PROBE43_MU_CNT {2} \
-   CONFIG.C_PROBE4_MU_CNT {2} \
-   CONFIG.C_PROBE4_WIDTH {1} \
-   CONFIG.C_PROBE5_MU_CNT {2} \
-   CONFIG.C_PROBE5_WIDTH {1} \
-   CONFIG.C_PROBE6_MU_CNT {2} \
-   CONFIG.C_PROBE6_WIDTH {1} \
-   CONFIG.C_PROBE7_MU_CNT {2} \
-   CONFIG.C_PROBE7_WIDTH {1} \
-   CONFIG.C_PROBE8_MU_CNT {2} \
-   CONFIG.C_PROBE8_WIDTH {1} \
-   CONFIG.C_PROBE9_MU_CNT {2} \
- ] $ila_2
 
   # Create instance: lxwrap_0, and set properties
   set lxwrap_0 [ create_bd_cell -type ip -vlnv user.org:user:lxwrap:1.0 lxwrap_0 ]
@@ -1171,6 +1112,14 @@ proc create_root_design { parentCell } {
   # Create instance: spi_cs_decoder, and set properties
   set spi_cs_decoder [ create_bd_cell -type ip -vlnv user.org:user:spi_decoder_3_to_n:1.0 spi_cs_decoder ]
 
+  # Create instance: system_ila_0, and set properties
+  set system_ila_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:system_ila:1.1 system_ila_0 ]
+  set_property -dict [ list \
+   CONFIG.C_MON_TYPE {NATIVE} \
+   CONFIG.C_NUM_OF_PROBES {1} \
+   CONFIG.C_PROBE0_TYPE {0} \
+ ] $system_ila_0
+
   # Create instance: vcc, and set properties
   set vcc [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 vcc ]
 
@@ -1189,7 +1138,8 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets axi_interconnect_peripherals_M01
   connect_bd_intf_net -intf_net axi_interconnect_peripherals_M04_AXI [get_bd_intf_pins adc1_dma/S_AXI_LITE] [get_bd_intf_pins axi_interconnect_peripherals/M04_AXI]
   connect_bd_intf_net -intf_net display_M_AXI_MM2S [get_bd_intf_pins axi_interconnect_memory_ps/S00_AXI] [get_bd_intf_pins display/M_AXI_MM2S]
   connect_bd_intf_net -intf_net ethernet_gmii_to_mii_adapter_0_ETHERNET_MII [get_bd_intf_ports ETHERNET_MII] [get_bd_intf_pins ethernet_gmii_to_mii_adapter_0/ETHERNET_MII]
-  connect_bd_intf_net -intf_net lxwrap_0_adc0 [get_bd_intf_pins adc0_dma/S_AXIS_S2MM] [get_bd_intf_pins lxwrap_0/adc0]
+  connect_bd_intf_net -intf_net lxwrap_0_adc0 [get_bd_intf_pins adc0_dma/S_AXIS_S2MM] [get_bd_intf_pins lxwrap_0/adc0s]
+  connect_bd_intf_net -intf_net lxwrap_0_adc1s [get_bd_intf_pins adc1_dma/S_AXIS_S2MM] [get_bd_intf_pins lxwrap_0/adc1s]
   connect_bd_intf_net -intf_net mig_7series_0_DDR3 [get_bd_intf_ports DDR_PL] [get_bd_intf_pins mig_7series_0/DDR3]
   connect_bd_intf_net -intf_net processing_system7_0_DDR [get_bd_intf_ports DDR] [get_bd_intf_pins processing_system7_0/DDR]
   connect_bd_intf_net -intf_net processing_system7_0_FIXED_IO [get_bd_intf_ports FIXED_IO] [get_bd_intf_pins processing_system7_0/FIXED_IO]
@@ -1201,14 +1151,18 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets axi_interconnect_peripherals_M01
   connect_bd_net -net ADC_0_1 [get_bd_ports ADC_0] [get_bd_pins lxwrap_0/adc0]
   connect_bd_net -net ARESETN_1 [get_bd_pins axi_acq_interconnect/ARESETN] [get_bd_pins axi_interconnect_memory_ps/ARESETN] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/interconnect_aresetn]
   connect_bd_net -net ARESETN_2 [get_bd_pins axi_interconnect_peripherals/ARESETN] [get_bd_pins proc_sys_reset_clk_domain_peripherals/interconnect_aresetn]
-  connect_bd_net -net M00_ARESETN_1 [get_bd_pins adc0_dma/axi_resetn] [get_bd_pins adc1_dma/axi_resetn] [get_bd_pins axi_acq_interconnect/S02_ARESETN] [get_bd_pins axi_interconnect_peripherals/M00_ARESETN] [get_bd_pins axi_interconnect_peripherals/M01_ARESETN] [get_bd_pins axi_interconnect_peripherals/M02_ARESETN] [get_bd_pins axi_interconnect_peripherals/M03_ARESETN] [get_bd_pins axi_interconnect_peripherals/M04_ARESETN] [get_bd_pins axi_interconnect_peripherals/S00_ARESETN] [get_bd_pins display/axi_resetn] [get_bd_pins proc_sys_reset_clk_domain_peripherals/peripheral_aresetn]
+  connect_bd_net -net M00_ARESETN_1 [get_bd_pins adc0_dma/axi_resetn] [get_bd_pins adc1_dma/axi_resetn] [get_bd_pins axi_acq_interconnect/S02_ARESETN] [get_bd_pins axi_interconnect_peripherals/M00_ARESETN] [get_bd_pins axi_interconnect_peripherals/M01_ARESETN] [get_bd_pins axi_interconnect_peripherals/M02_ARESETN] [get_bd_pins axi_interconnect_peripherals/M03_ARESETN] [get_bd_pins axi_interconnect_peripherals/M04_ARESETN] [get_bd_pins axi_interconnect_peripherals/M05_ARESETN] [get_bd_pins axi_interconnect_peripherals/S00_ARESETN] [get_bd_pins display/axi_resetn] [get_bd_pins proc_sys_reset_clk_domain_peripherals/peripheral_aresetn]
+  connect_bd_net -net adc1_0_1 [get_bd_ports ADC_1] [get_bd_pins lxwrap_0/adc1]
   connect_bd_net -net concat_int_dout [get_bd_pins concat_int/dout] [get_bd_pins processing_system7_0/IRQ_F2P]
+  connect_bd_net -net debug [get_bd_pins lxwrap_0/debug] [get_bd_pins system_ila_0/probe0]
+  set_property -dict [ list \
+HDL_ATTRIBUTE.DEBUG {true} \
+ ] [get_bd_nets debug]
   connect_bd_net -net display_VID_DATA [get_bd_ports VID_DATA] [get_bd_pins display/VID_DATA]
   connect_bd_net -net display_pixel_clock [get_bd_ports VID_PIXEL_CLK] [get_bd_pins display/pixel_clock]
   connect_bd_net -net display_vdma_mm2s_introut [get_bd_pins concat_int/In0] [get_bd_pins display/vdma_mm2s_introut]
   connect_bd_net -net display_vid_display_out_hsync [get_bd_ports VID_HSYNC] [get_bd_pins display/vid_display_out_hsync]
   connect_bd_net -net display_vid_display_out_vsync [get_bd_ports VID_VSYNC] [get_bd_pins display/vid_display_out_vsync]
-  connect_bd_net -net lxwrap_0_debug [get_bd_pins ila_2/probe0] [get_bd_pins lxwrap_0/debug]
   connect_bd_net -net lxwrap_0_mux_S [get_bd_ports OFFSETMUX_S] [get_bd_pins lxwrap_0/mux_S]
   connect_bd_net -net lxwrap_0_mux_nE [get_bd_ports OFFSETMUX_EN] [get_bd_pins lxwrap_0/mux_nE]
   connect_bd_net -net lxwrap_0_spi_DIN [get_bd_ports OFFSETDAC_SDATA] [get_bd_pins lxwrap_0/spi_DIN]
@@ -1218,11 +1172,11 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets axi_interconnect_peripherals_M01
   connect_bd_net -net mig_7series_0_ui_clk [get_bd_pins axi_acq_interconnect/M00_ACLK] [get_bd_pins mig_7series_0/ui_clk] [get_bd_pins rst_mig_7series_0_100M/slowest_sync_clk]
   connect_bd_net -net mig_7series_0_ui_clk_sync_rst [get_bd_pins mig_7series_0/ui_clk_sync_rst] [get_bd_pins rst_mig_7series_0_100M/ext_reset_in]
   connect_bd_net -net proc_sys_reset_clk_domain_peripherals_peripheral_reset [get_bd_pins lxwrap_0/sys_rst] [get_bd_pins proc_sys_reset_clk_domain_peripherals/peripheral_reset]
-  connect_bd_net -net proc_sys_reset_clk_domain_ps_memory_peripheral_aresetn [get_bd_pins axi_acq_interconnect/S00_ARESETN] [get_bd_pins axi_acq_interconnect/S01_ARESETN] [get_bd_pins axi_interconnect_memory_ps/M00_ARESETN] [get_bd_pins axi_interconnect_memory_ps/S00_ARESETN] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/peripheral_aresetn]
+  connect_bd_net -net proc_sys_reset_clk_domain_ps_memory_peripheral_aresetn [get_bd_pins axi_acq_interconnect/S00_ARESETN] [get_bd_pins axi_acq_interconnect/S01_ARESETN] [get_bd_pins axi_acq_interconnect/S03_ARESETN] [get_bd_pins axi_interconnect_memory_ps/M00_ARESETN] [get_bd_pins axi_interconnect_memory_ps/S00_ARESETN] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/peripheral_aresetn]
   connect_bd_net -net proc_sys_reset_clk_domain_ps_memory_peripheral_reset [get_bd_pins lxwrap_0/adc_axis_rst] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/peripheral_reset]
   connect_bd_net -net processing_system7_0_FCLK_CLK0 [get_bd_pins mig_7series_0/sys_clk_i] [get_bd_pins processing_system7_0/FCLK_CLK0]
-  connect_bd_net -net processing_system7_0_FCLK_CLK1 [get_bd_pins adc0_dma/s_axi_lite_aclk] [get_bd_pins adc1_dma/s_axi_lite_aclk] [get_bd_pins axi_acq_interconnect/S02_ACLK] [get_bd_pins axi_interconnect_peripherals/ACLK] [get_bd_pins axi_interconnect_peripherals/M00_ACLK] [get_bd_pins axi_interconnect_peripherals/M01_ACLK] [get_bd_pins axi_interconnect_peripherals/M02_ACLK] [get_bd_pins axi_interconnect_peripherals/M03_ACLK] [get_bd_pins axi_interconnect_peripherals/M04_ACLK] [get_bd_pins axi_interconnect_peripherals/S00_ACLK] [get_bd_pins display/peripheral_clock] [get_bd_pins ila_1/clk] [get_bd_pins lxwrap_0/sys_clk] [get_bd_pins proc_sys_reset_clk_domain_peripherals/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK1] [get_bd_pins processing_system7_0/M_AXI_GP1_ACLK]
-  connect_bd_net -net processing_system7_0_FCLK_CLK2 [get_bd_pins adc0_dma/m_axi_s2mm_aclk] [get_bd_pins adc1_dma/m_axi_s2mm_aclk] [get_bd_pins axi_acq_interconnect/ACLK] [get_bd_pins axi_acq_interconnect/S00_ACLK] [get_bd_pins axi_acq_interconnect/S01_ACLK] [get_bd_pins axi_interconnect_memory_ps/ACLK] [get_bd_pins axi_interconnect_memory_ps/M00_ACLK] [get_bd_pins axi_interconnect_memory_ps/S00_ACLK] [get_bd_pins display/memory_clock] [get_bd_pins ila_0/clk] [get_bd_pins ila_2/clk] [get_bd_pins lxwrap_0/adc_axis_clk] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK2] [get_bd_pins processing_system7_0/S_AXI_HP0_ACLK]
+  connect_bd_net -net processing_system7_0_FCLK_CLK1 [get_bd_pins adc0_dma/s_axi_lite_aclk] [get_bd_pins adc1_dma/s_axi_lite_aclk] [get_bd_pins axi_acq_interconnect/S02_ACLK] [get_bd_pins axi_interconnect_peripherals/ACLK] [get_bd_pins axi_interconnect_peripherals/M00_ACLK] [get_bd_pins axi_interconnect_peripherals/M01_ACLK] [get_bd_pins axi_interconnect_peripherals/M02_ACLK] [get_bd_pins axi_interconnect_peripherals/M03_ACLK] [get_bd_pins axi_interconnect_peripherals/M04_ACLK] [get_bd_pins axi_interconnect_peripherals/M05_ACLK] [get_bd_pins axi_interconnect_peripherals/S00_ACLK] [get_bd_pins display/peripheral_clock] [get_bd_pins ila_1/clk] [get_bd_pins lxwrap_0/sys_clk] [get_bd_pins proc_sys_reset_clk_domain_peripherals/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK1] [get_bd_pins processing_system7_0/M_AXI_GP1_ACLK] [get_bd_pins system_ila_0/clk]
+  connect_bd_net -net processing_system7_0_FCLK_CLK2 [get_bd_pins adc0_dma/m_axi_s2mm_aclk] [get_bd_pins adc1_dma/m_axi_s2mm_aclk] [get_bd_pins axi_acq_interconnect/ACLK] [get_bd_pins axi_acq_interconnect/S00_ACLK] [get_bd_pins axi_acq_interconnect/S01_ACLK] [get_bd_pins axi_acq_interconnect/S03_ACLK] [get_bd_pins axi_interconnect_memory_ps/ACLK] [get_bd_pins axi_interconnect_memory_ps/M00_ACLK] [get_bd_pins axi_interconnect_memory_ps/S00_ACLK] [get_bd_pins display/memory_clock] [get_bd_pins ila_0/clk] [get_bd_pins lxwrap_0/adc_axis_clk] [get_bd_pins proc_sys_reset_clk_domain_ps_memory/slowest_sync_clk] [get_bd_pins processing_system7_0/FCLK_CLK2] [get_bd_pins processing_system7_0/S_AXI_HP0_ACLK]
   connect_bd_net -net processing_system7_0_FCLK_RESET0_N [get_bd_pins mig_7series_0/sys_rst] [get_bd_pins processing_system7_0/FCLK_RESET0_N]
   connect_bd_net -net processing_system7_0_FCLK_RESET1_N [get_bd_pins proc_sys_reset_clk_domain_peripherals/ext_reset_in] [get_bd_pins processing_system7_0/FCLK_RESET1_N]
   connect_bd_net -net processing_system7_0_FCLK_RESET2_N [get_bd_pins proc_sys_reset_clk_domain_ps_memory/ext_reset_in] [get_bd_pins processing_system7_0/FCLK_RESET2_N]
@@ -1276,4 +1230,6 @@ connect_bd_intf_net -intf_net [get_bd_intf_nets axi_interconnect_peripherals_M01
 
 create_root_design ""
 
+
+common::send_msg_id "BD_TCL-1000" "WARNING" "This Tcl script was generated from a block design that has not been validated. It is possible that design <$design_name> may result in errors during validation."
 

--- a/projects/sds1104xe/sds1104xe_top.xdc
+++ b/projects/sds1104xe/sds1104xe_top.xdc
@@ -286,3 +286,84 @@ set_property IOSTANDARD LVDS_25 [get_ports ADC_0[18]]
 set_property DIFF_TERM TRUE [get_ports ADC_0[18]]
 set_property PACKAGE_PIN AA9 [get_ports ADC_0[18]]
 
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[0]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[0]]
+set_property PACKAGE_PIN AB7 [get_ports ADC_1[0]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[1]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[1]]
+set_property PACKAGE_PIN AB6 [get_ports ADC_1[1]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[2]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[2]]
+set_property PACKAGE_PIN AB5 [get_ports ADC_1[2]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[3]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[3]]
+set_property PACKAGE_PIN AB4 [get_ports ADC_1[3]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[4]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[4]]
+set_property PACKAGE_PIN V7 [get_ports ADC_1[4]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[5]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[5]]
+set_property PACKAGE_PIN W7 [get_ports ADC_1[5]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[6]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[6]]
+set_property PACKAGE_PIN U6 [get_ports ADC_1[6]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[7]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[7]]
+set_property PACKAGE_PIN U5 [get_ports ADC_1[7]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[8]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[8]]
+set_property PACKAGE_PIN W6 [get_ports ADC_1[8]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[9]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[9]]
+set_property PACKAGE_PIN W5 [get_ports ADC_1[9]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[10]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[10]]
+set_property PACKAGE_PIN V5 [get_ports ADC_1[10]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[11]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[11]]
+set_property PACKAGE_PIN V4 [get_ports ADC_1[11]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[12]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[12]]
+set_property PACKAGE_PIN Y4 [get_ports ADC_1[12]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[13]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[13]]
+set_property PACKAGE_PIN AA4 [get_ports ADC_1[13]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[14]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[14]]
+set_property PACKAGE_PIN AB2 [get_ports ADC_1[14]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[15]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[15]]
+set_property PACKAGE_PIN AB1 [get_ports ADC_1[15]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[16]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[16]]
+set_property PACKAGE_PIN Y6 [get_ports ADC_1[16]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[17]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[17]]
+set_property PACKAGE_PIN Y5 [get_ports ADC_1[17]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[18]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[18]]
+set_property PACKAGE_PIN AA7 [get_ports ADC_1[18]]
+
+set_property IOSTANDARD LVDS_25 [get_ports ADC_1[19]]
+set_property DIFF_TERM TRUE [get_ports ADC_1[19]]
+set_property PACKAGE_PIN AA6 [get_ports ADC_1[19]]
+


### PR DESCRIPTION
This adds support for both ADCs. Further, this toggles TLAST every now and then to make the DMA IP (more) happy. 

cheapscope.py is modified for the updated memory map (offsetdac moved to 0x1000, adcif1 is now at 0x800), and now defaults to ADC1 (corresponds to CH3 / blue).